### PR TITLE
Allow shorthand binding of elemens to model properties. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ A string value which is used to map a model attribute value to the selected view
   }
  ```
 
+This simple binding can also be expressed in shortform.
+
+```javascript  
+  bindings: {
+    '#header': 'headerName'
+  }
+```
+
 The value of `view.model.get('headerName')` is bound to `view.$('#header')`.
 
 ### format

--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -37,13 +37,25 @@
 			// Iterate through the selectors in the bindings configuration and configure
 			// the various options for each field.
 			_.each(_.keys(bindings), function(selector) {
-				var getVal, modelEvents, formElEvent,
-					config = bindings[selector] || {},
-					$el = self.$(selector),
-					format = config.format,
-					modelAttr = config.modelAttr,
-					attributes = config.attributes || [];
+				
 
+				var getVal, modelEvents, formElEvent, config, $el, format, modelAttr, attributes;
+
+				config = bindings[selector] || {};
+				
+				// Allow shorthand setting of model attributes
+				if (typeof config === 'string') {
+					config = {
+						modelAttr: config
+					};
+				}
+
+				$el = self.$(selector);
+				format = config.format;
+				modelAttr = config.modelAttr;
+				attributes = config.attributes || [];
+
+				
 				// Fail fast if the selector didn't match an element.
 				if (!$el.length) return false;
 		

--- a/test/bindData.js
+++ b/test/bindData.js
@@ -104,6 +104,23 @@ $(document).ready(function() {
 		equal(view.$('#test5').text(), 'evian');
 	});
 
+	test('stickit (shorthand bindings)', function() {
+		model.set({'water':'fountain'});
+		view.model = model;
+		view.templateId = 'jst5';
+		view.bindings = {
+			'#test5': 'water'
+		};
+		$('#qunit-fixture').html(view.render().el);
+		
+		equal(view.$('#test5').text(), 'fountain');
+
+		model.set('water', 'evian');
+
+		equal(view.$('#test5').text(), 'evian');
+
+	});
+
 	test('stickit (multiple models and bindings)', function() {
 	
 		// Test sticking two times to two different models and configs.


### PR DESCRIPTION
Simplified syntax for the most basic binding: selector to model property
