### PR TITLE
Fix select options existence predicate

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -210,7 +210,7 @@
 			var optList, list = selectConfig.collection, fieldVal = model.get(modelAttr);
 
 			// Get the current selected option value if the select options exist.
-			if ($el[0].options && $el[0].selectedIndex)
+			if ($el[0].options.length && $el[0].selectedIndex >= 0)
 				originalVal = $($el[0].options[$el[0].selectedIndex]).data('stickit_bind_val');
 			
 			$el.html('');


### PR DESCRIPTION
Hi.

I encountered some issues with Backbone.stickit on Internet Explorer (tried it on IE7 and IE8). Stickit would always try to get the currently selected option of a select input, even if it was empty. Here's what I found:
- `$el[0].options` would always evaluate to `true` even if the select object didn't have any option elements. So instead I'm checking if its length is truthy.
- `selectedIndex` would evaluate to `true`, because when there is no selected item `selectedIndex` equals `-1`. Instead I'm checking whether or not it's equal or greater than zero.
