### PR TITLE
Fix an issue with selects getting the correct val

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -182,7 +182,7 @@
 	getFormElVal = function($el) {
 		var val;
 		if ($el.is('input[type=checkbox]')) val = $el.prop('checked');
-		else if ($el.is('select')) val = $el.find('option:selected').data('stickit_bind_val');
+		else if ($el.is('select')) val = $el.find('option:selected').data('stickit_bind_val') || $el.val();
 		else if ($el.is('input[type=number]')) val = Number($el.val());
 		else if ($el.is('input[type="radio"]')) val = $el.filter(':checked').val();
 		else val = $el.val();


### PR DESCRIPTION
I ran into a use case for select's in which the value of a select box is manually set and therefor was not getting a `selected="selected"` onto the option element. This pull request adds another check of the `.val()` of the actual select element in case there is no `:selected` option.
