### PR TITLE
Let Backbone say what `$` its using

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -333,4 +333,4 @@
 		});
 	};
 
-})(window.jQuery || window.Zepto);
+})(Backbone.$);


### PR DESCRIPTION
Also removes the requirement for jQuery / Zepto to be declared globally.
