### PR TITLE
Allow null or empty string in select options

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -154,7 +154,7 @@
 	// Evaluates the given `path` (in object/dot-notation) relative to the given `obj`.
 	var evaluatePath = function(obj, path) {
 		var pathParts = (path || '').split('.');
-		return _.reduce(pathParts, function(memo, i) { return memo[i]; }, obj) || obj;
+		return _.reduce(pathParts, function(memo, i) { return memo[i]; }, obj);
 	};
 
 	// If the given `fn` is a string, then view[fn] is called, otherwise it is a function


### PR DESCRIPTION
The logic in evaluatePath seems to have a problem where a select option with null or "" is causing the entire object to be assigned to the element's data instead of just the value.  This seems to fix things.
