### PR TITLE
Added Default Paths to SelectionOptions

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -325,8 +325,8 @@
 			// If the list contains a null/undefined value, then an empty option should
 			// be appended in the list; otherwise, fill the option with text and value.
 			if (obj != null) {
-				option.text(evaluatePath(obj, selectConfig.labelPath));
-				optionVal = evaluatePath(obj, selectConfig.valuePath);
+				option.text(evaluatePath(obj, selectConfig.labelPath || "label"));
+				optionVal = evaluatePath(obj, selectConfig.valuePath || "value");
 			} else if ($el.find('option').length && $el.find('option:eq(0)').data('stickit_bind_val') == null) return false;
 
 			// Save the option value so that we can reference it later.


### PR DESCRIPTION
All selectOptions now have a default labelPath / valuePath. I been writing the same values over and over. Makes more sense to add a default.
