### PR TITLE
For discussion: Extract overridable methods to Backbone.Stickit

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -1,394 +1,394 @@
 (function($) {
 
-	var isFormEl = function($el) {
-		return _.indexOf(['CHECKBOX', 'INPUT', 'SELECT', 'TEXTAREA'], $el[0].nodeName, true) > -1;
-	};
+  var isFormEl = function($el) {
+    return _.indexOf(['CHECKBOX', 'INPUT', 'SELECT', 'TEXTAREA'], $el[0].nodeName, true) > -1;
+  };
 
-	var isCheckbox = function($el) { return $el.is('input[type=checkbox]'); };
+  var isCheckbox = function($el) { return $el.is('input[type=checkbox]'); };
 
-	var isRadio = function($el) { return $el.is('input[type="radio"]'); };
+  var isRadio = function($el) { return $el.is('input[type="radio"]'); };
 
-	var isNumber = function($el) { return $el.is('input[type=number]'); };
+  var isNumber = function($el) { return $el.is('input[type=number]'); };
 
-	var isSelect = function($el) { return $el.is('select'); };
+  var isSelect = function($el) { return $el.is('select'); };
 
-	var isTextarea = function($el) { return $el.is('textarea'); };
+  var isTextarea = function($el) { return $el.is('textarea'); };
 
-	var isInput = function($el) { return $el.is('input'); };
+  var isInput = function($el) { return $el.is('input'); };
 
-	var isContenteditable = function($el) { return $el.is('[contenteditable="true"]'); };
+  var isContenteditable = function($el) { return $el.is('[contenteditable="true"]'); };
 
-	var Stickit = Backbone.Stickit = {
+  var Stickit = Backbone.Stickit = {
 
-		isObservable: function($el) {
-			return isFormEl($el) || isContenteditable($el);
-		},
+    isObservable: function($el) {
+      return isFormEl($el) || isContenteditable($el);
+    },
 
-		updateEl: function($el, val, config) {
+    updateEl: function($el, val, config) {
 
-			var selectConfig = config.selectOptions,
-					updateMethod = config.updateMethod || 'text';
+      var selectConfig = config.selectOptions,
+          updateMethod = config.updateMethod || 'text';
 
-			if (isRadio($el)) $el.filter('[value="'+val+'"]').prop('checked', true);
-			else if (isCheckbox($el)) {
-				if ($el.length > 1) {
-					// There are multiple checkboxes so we need to go through them and check
-					// any that have value attributes that match what's in the array of `val`s.
-					val || (val = []);
-					_.each($el, function(el) {
-						if (_.indexOf(val, $(el).val()) > -1) $(el).prop('checked', true);
-						else $(el).prop('checked', false);
-					});
-				} else {
-					if (_.isBoolean(val)) $el.prop('checked', val);
-					else $el.prop('checked', val == $el.val());
-				}
-			} else if (isInput($el) || isTextarea($el)) $el.val(val);
-			else if (isContenteditable($el)) $el.html(val);
-			else if (isSelect($el)) {
-				var optList, list = selectConfig.collection, isMultiple = $el.prop('multiple');
+      if (isRadio($el)) $el.filter('[value="'+val+'"]').prop('checked', true);
+      else if (isCheckbox($el)) {
+        if ($el.length > 1) {
+          // There are multiple checkboxes so we need to go through them and check
+          // any that have value attributes that match what's in the array of `val`s.
+          val || (val = []);
+          _.each($el, function(el) {
+            if (_.indexOf(val, $(el).val()) > -1) $(el).prop('checked', true);
+            else $(el).prop('checked', false);
+          });
+        } else {
+          if (_.isBoolean(val)) $el.prop('checked', val);
+          else $el.prop('checked', val == $el.val());
+        }
+      } else if (isInput($el) || isTextarea($el)) $el.val(val);
+      else if (isContenteditable($el)) $el.html(val);
+      else if (isSelect($el)) {
+        var optList, list = selectConfig.collection, isMultiple = $el.prop('multiple');
 
-				$el.html('');
+        $el.html('');
 
-				// The `list` configuration is a function that returns the options list or a string
-				// which represents the path to the list relative to `window`.
-				optList = _.isFunction(list) ? applyViewFn(view, list) : evaluatePath(window, list);
+        // The `list` configuration is a function that returns the options list or a string
+        // which represents the path to the list relative to `window`.
+        optList = _.isFunction(list) ? applyViewFn(view, list) : evaluatePath(window, list);
 
-				// Add an empty default option if the current model attribute isn't defined.
-				if (val == null)
-					$el.append('<option/>').find('option').prop('selected', true).data('stickit_bind_val', val);
+        // Add an empty default option if the current model attribute isn't defined.
+        if (val == null)
+          $el.append('<option/>').find('option').prop('selected', true).data('stickit_bind_val', val);
 
-				if (_.isArray(optList)) {
-					addSelectOptions(optList, $el, selectConfig, val, isMultiple);
-				} else {
-					// If the optList is an object, then it should be used to define an optgroup. An
-					// optgroup object configuration looks like the following:
-					//
-					//     {
-					//       'opt_labels': ['Looney Tunes', 'Three Stooges'],
-					//       'Looney Tunes': [{id: 1, name: 'Bugs Bunny'}, {id: 2, name: 'Donald Duck'}],
-					//       'Three Stooges': [{id: 3, name : 'moe'}, {id: 4, name : 'larry'}, {id: 5, name : 'curly'}]
-					//     }
-					//
-					_.each(optList.opt_labels, function(label) {
-						var $group = $('<optgroup/>').attr('label', label);
-						addSelectOptions(optList[label], $group, selectConfig, val, isMultiple);
-						$el.append($group);
-					});
-				}
-			} else {
-				$el[updateMethod](val);
-			}
-		},
+        if (_.isArray(optList)) {
+          addSelectOptions(optList, $el, selectConfig, val, isMultiple);
+        } else {
+          // If the optList is an object, then it should be used to define an optgroup. An
+          // optgroup object configuration looks like the following:
+          //
+          //     {
+          //       'opt_labels': ['Looney Tunes', 'Three Stooges'],
+          //       'Looney Tunes': [{id: 1, name: 'Bugs Bunny'}, {id: 2, name: 'Donald Duck'}],
+          //       'Three Stooges': [{id: 3, name : 'moe'}, {id: 4, name : 'larry'}, {id: 5, name : 'curly'}]
+          //     }
+          //
+          _.each(optList.opt_labels, function(label) {
+            var $group = $('<optgroup/>').attr('label', label);
+            addSelectOptions(optList[label], $group, selectConfig, val, isMultiple);
+            $el.append($group);
+          });
+        }
+      } else {
+        $el[updateMethod](val);
+      }
+    },
 
-		// Gets the value from the given element, with the optional hint that the value is html.
-		getElVal: function($el, isHTML) {
-			var val;
-			if (isFormEl($el)) {
-				if (isNumber($el)) val = Number($el.val());
-				else if (isRadio($el)) val = $el.filter(':checked').val();
-				else if (isCheckbox($el)) {
-					if ($el.length > 1) {
-						val = _.reduce($el, function(memo, el) {
-							if ($(el).prop('checked')) memo.push($(el).val());
-							return memo;
-						}, []);
-					} else {
-						val = $el.prop('checked');
-						// If the checkbox has a value attribute defined, then
-						// use that value. Most browsers use "on" as a default.
-						var boxval = $el.val();
-						if (boxval != 'on' && boxval != null) {
-							if (val) val = $el.val();
-							else val = null;
-						}
-					}
-				} else if (isSelect($el)) {
-					if ($el.prop('multiple')) {
-						val = $el.find('option:selected').map(function() {
-							return $(this).data('stickit_bind_val');
-						}).get();
-					} else {
-						val = $el.find('option:selected').data('stickit_bind_val');
-					}
-				}
-				else val = $el.val();
-			} else {
-				if (isHTML) val = $el.html();
-				else val = $el.text();
-			}
-			return val;
-		}
+    // Gets the value from the given element, with the optional hint that the value is html.
+    getElVal: function($el, isHTML) {
+      var val;
+      if (isFormEl($el)) {
+        if (isNumber($el)) val = Number($el.val());
+        else if (isRadio($el)) val = $el.filter(':checked').val();
+        else if (isCheckbox($el)) {
+          if ($el.length > 1) {
+            val = _.reduce($el, function(memo, el) {
+              if ($(el).prop('checked')) memo.push($(el).val());
+              return memo;
+            }, []);
+          } else {
+            val = $el.prop('checked');
+            // If the checkbox has a value attribute defined, then
+            // use that value. Most browsers use "on" as a default.
+            var boxval = $el.val();
+            if (boxval != 'on' && boxval != null) {
+              if (val) val = $el.val();
+              else val = null;
+            }
+          }
+        } else if (isSelect($el)) {
+          if ($el.prop('multiple')) {
+            val = $el.find('option:selected').map(function() {
+              return $(this).data('stickit_bind_val');
+            }).get();
+          } else {
+            val = $el.find('option:selected').data('stickit_bind_val');
+          }
+        }
+        else val = $el.val();
+      } else {
+        if (isHTML) val = $el.html();
+        else val = $el.text();
+      }
+      return val;
+    }
 
-	};
+  };
 
-	// Backbone.View Mixins
-	// --------------------
+  // Backbone.View Mixins
+  // --------------------
 
-	_.extend(Backbone.View.prototype, {
+  _.extend(Backbone.View.prototype, {
 
-		// Collection of model event bindings.
-		//   [{model,event,fn}, ...]
-		_modelBindings: null,
+    // Collection of model event bindings.
+    //   [{model,event,fn}, ...]
+    _modelBindings: null,
 
-		// Unbind the model bindings that are referenced in `this._modelBindings`. If
-		// the optional `model` parameter is defined, then only delete bindings for
-		// the given `model`.
-		unstickModel: function(model) {
-			_.each(this._modelBindings, _.bind(function(binding, i) {
-				if (model && binding.model !== model) return false;
-				binding.model.off(binding.event, binding.fn);
-				delete this._modelBindings[i];
-			}, this));
-			this._modelBindings = _.compact(this._modelBindings);
-		},
+    // Unbind the model bindings that are referenced in `this._modelBindings`. If
+    // the optional `model` parameter is defined, then only delete bindings for
+    // the given `model`.
+    unstickModel: function(model) {
+      _.each(this._modelBindings, _.bind(function(binding, i) {
+        if (model && binding.model !== model) return false;
+        binding.model.off(binding.event, binding.fn);
+        delete this._modelBindings[i];
+      }, this));
+      this._modelBindings = _.compact(this._modelBindings);
+    },
 
-		// Using `this.bindings` configuration or the `optionalBindingsConfig`, binds `this.model`
-		// or the `optionalModel` to elements in the view.
-		stickit: function(optionalModel, optionalBindingsConfig) {
-			var self = this,
-				model = optionalModel || this.model,
-				bindings = optionalBindingsConfig || this.bindings || {},
-				props = ['autofocus', 'autoplay', 'async', 'checked', 'controls', 'defer', 'disabled', 'hidden', 'loop', 'multiple', 'open', 'readonly', 'required', 'scoped', 'selected'];
+    // Using `this.bindings` configuration or the `optionalBindingsConfig`, binds `this.model`
+    // or the `optionalModel` to elements in the view.
+    stickit: function(optionalModel, optionalBindingsConfig) {
+      var self = this,
+        model = optionalModel || this.model,
+        bindings = optionalBindingsConfig || this.bindings || {},
+        props = ['autofocus', 'autoplay', 'async', 'checked', 'controls', 'defer', 'disabled', 'hidden', 'loop', 'multiple', 'open', 'readonly', 'required', 'scoped', 'selected'];
 
-			this._modelBindings || (this._modelBindings = []);
-			this.unstickModel(model);
+      this._modelBindings || (this._modelBindings = []);
+      this.unstickModel(model);
 
-			// Since `this.events` may be a function or hash, we'll create a stickitEvents
-			// property where we can mix in our own set of events. We also need to support
-			// multiple calls to `stickit()` in a single Backbone View.
-			this._stickitEvents = _(_.result(this, 'events') || {}).extend(this._stickitEvents);
+      // Since `this.events` may be a function or hash, we'll create a stickitEvents
+      // property where we can mix in our own set of events. We also need to support
+      // multiple calls to `stickit()` in a single Backbone View.
+      this._stickitEvents = _(_.result(this, 'events') || {}).extend(this._stickitEvents);
 
-			// Iterate through the selectors in the bindings configuration and configure
-			// the various options for each field.
-			_.each(_.keys(bindings), function(selector) {
-				var $el, options, modelAttr, visibleCb,
-					config = bindings[selector] || {},
-					bindKey = _.uniqueId();
-				
-				// Support ':el' selector - special case selector for the view managed delegate.
-				if (selector != ':el') $el = self.$(selector);
-				else {
-					$el = self.$el;
-					selector = '';
-				}
+      // Iterate through the selectors in the bindings configuration and configure
+      // the various options for each field.
+      _.each(_.keys(bindings), function(selector) {
+        var $el, options, modelAttr, visibleCb,
+          config = bindings[selector] || {},
+          bindKey = _.uniqueId();
 
-				// Fail fast if the selector didn't match an element.
-				if (!$el.length) return false;
-		
-				// Allow shorthand setting of model attributes - `'selector':'observe'`.
-				if (_.isString(config)) config = {observe:config};
+        // Support ':el' selector - special case selector for the view managed delegate.
+        if (selector != ':el') $el = self.$(selector);
+        else {
+          $el = self.$el;
+          selector = '';
+        }
 
-				// Keep backward-compatibility for `modelAttr` which was renamed `observe`.
-				modelAttr = config.observe || config.modelAttr;
+        // Fail fast if the selector didn't match an element.
+        if (!$el.length) return false;
 
-				if (config.updateModel == null) config.updateModel = true;
-				if (config.updateView == null) config.updateView = true;
+        // Allow shorthand setting of model attributes - `'selector':'observe'`.
+        if (_.isString(config)) config = {observe:config};
 
-				// Keep backward-compatibility for `format` which was renamed `onGet`.
-				if (config.format && !config.onGet) config.onGet = config.format;
+        // Keep backward-compatibility for `modelAttr` which was renamed `observe`.
+        modelAttr = config.observe || config.modelAttr;
 
-				// Create the model set options with a unique `bindKey` so that we
-				// can avoid double-binding in the `change:attribute` event handler.
-				options = _.extend({bindKey:bindKey}, config.setOptions || {});
+        if (config.updateModel == null) config.updateModel = true;
+        if (config.updateView == null) config.updateView = true;
 
-				// Setup the attributes configuration - a list that maps an attribute or
-				// property `name`, to an `observe`d model attribute, using an optional
-				// `onGet` formatter.
-				//
-				//     [{
-				//       name: 'attributeOrPropertyName',
-				//       observe: 'modelAttrName'
-				//       onGet: function(modelAttrVal, modelAttrName) { ... }
-				//     }, ...]
-				//
-				_.each(config.attributes || [], function(attrConfig) {
-					var lastClass = '',
-						observed = attrConfig.observe || modelAttr,
-						updateAttr = function() {
-							var updateType = _.indexOf(props, attrConfig.name, true) > -1 ? 'prop' : 'attr',
-								val = getVal(model, observed, attrConfig, self);
-							// If it is a class then we need to remove the last value and add the new.
-							if (attrConfig.name == 'class') {
-								$el.removeClass(lastClass).addClass(val);
-								lastClass = val;
-							}
-							else $el[updateType](attrConfig.name, val);
-						};
-					// Keep backward-compatibility for `format` which is now `onGet`.
-					if (attrConfig.format && !attrConfig.onGet) attrConfig.onGet = attrConfig.format;
-					_.each(_.flatten([observed]), function(attr) {
-						observeModelEvent(model, self, 'change:' + attr, updateAttr);
-					});
-					updateAttr();
-				});
+        // Keep backward-compatibility for `format` which was renamed `onGet`.
+        if (config.format && !config.onGet) config.onGet = config.format;
 
-				// If `visible` is configured, then the view element will be shown/hidden
-				// based on the truthiness of the modelattr's value or the result of the
-				// given callback. If a `visibleFn` is also supplied, then that callback
-				// will be executed to manually handle showing/hiding the view element.
-				if (config.visible != null) {
-					visibleCb = function() {
-						updateVisibleBindEl($el, getVal(model, modelAttr, config, self), modelAttr, config, self);
-					};
-					observeModelEvent(model, self, 'change:' + modelAttr, visibleCb);
-					visibleCb();
-					return false;
-				}
+        // Create the model set options with a unique `bindKey` so that we
+        // can avoid double-binding in the `change:attribute` event handler.
+        options = _.extend({bindKey:bindKey}, config.setOptions || {});
 
-				if (modelAttr) {
-					if (Stickit.isObservable($el)) {
-						// Bind events to the element which will update the model with changes.
-						_.each(config.eventsOverride || getModelEvents($el), function(type) {
-							self._stickitEvents[type+'.stickit '+selector] = function() {
-								var val = Stickit.getElVal($el, isContenteditable($el));
-								// Don't update the model if false is returned from the `updateModel` configuration.
-								if (evaluateBoolean(self, config.updateModel, val, modelAttr))
-								setVal(model, modelAttr, val, options, config.onSet, self);
-							};
-						});
-					}
+        // Setup the attributes configuration - a list that maps an attribute or
+        // property `name`, to an `observe`d model attribute, using an optional
+        // `onGet` formatter.
+        //
+        //     [{
+        //       name: 'attributeOrPropertyName',
+        //       observe: 'modelAttrName'
+        //       onGet: function(modelAttrVal, modelAttrName) { ... }
+        //     }, ...]
+        //
+        _.each(config.attributes || [], function(attrConfig) {
+          var lastClass = '',
+            observed = attrConfig.observe || modelAttr,
+            updateAttr = function() {
+              var updateType = _.indexOf(props, attrConfig.name, true) > -1 ? 'prop' : 'attr',
+                val = getVal(model, observed, attrConfig, self);
+              // If it is a class then we need to remove the last value and add the new.
+              if (attrConfig.name == 'class') {
+                $el.removeClass(lastClass).addClass(val);
+                lastClass = val;
+              }
+              else $el[updateType](attrConfig.name, val);
+            };
+          // Keep backward-compatibility for `format` which is now `onGet`.
+          if (attrConfig.format && !attrConfig.onGet) attrConfig.onGet = attrConfig.format;
+          _.each(_.flatten([observed]), function(attr) {
+            observeModelEvent(model, self, 'change:' + attr, updateAttr);
+          });
+          updateAttr();
+        });
 
-					// Setup a `change:modelAttr` observer to keep the view element in sync.
-					// `modelAttr` may be an array of attributes or a single string value.
-					_.each(_.flatten([modelAttr]), function(attr) {
-						observeModelEvent(model, self, 'change:'+attr, function(model, val, options) {
-							if (options == null || options.bindKey != bindKey)
-								updateViewBindEl(self, $el, config, getVal(model, modelAttr, config, self), model);
-						});
-					});
+        // If `visible` is configured, then the view element will be shown/hidden
+        // based on the truthiness of the modelattr's value or the result of the
+        // given callback. If a `visibleFn` is also supplied, then that callback
+        // will be executed to manually handle showing/hiding the view element.
+        if (config.visible != null) {
+          visibleCb = function() {
+            updateVisibleBindEl($el, getVal(model, modelAttr, config, self), modelAttr, config, self);
+          };
+          observeModelEvent(model, self, 'change:' + modelAttr, visibleCb);
+          visibleCb();
+          return false;
+        }
 
-					updateViewBindEl(self, $el, config, getVal(model, modelAttr, config, self), model, true);
-				}
-			});
+        if (modelAttr) {
+          if (Stickit.isObservable($el)) {
+            // Bind events to the element which will update the model with changes.
+            _.each(config.eventsOverride || getModelEvents($el), function(type) {
+              self._stickitEvents[type+'.stickit '+selector] = function() {
+                var val = Stickit.getElVal($el, isContenteditable($el));
+                // Don't update the model if false is returned from the `updateModel` configuration.
+                if (evaluateBoolean(self, config.updateModel, val, modelAttr))
+                setVal(model, modelAttr, val, options, config.onSet, self);
+              };
+            });
+          }
 
-			// Have Backbone delegate any newly added events in `_stickitEvents`.
-			this.delegateEvents(this._stickitEvents);
+          // Setup a `change:modelAttr` observer to keep the view element in sync.
+          // `modelAttr` may be an array of attributes or a single string value.
+          _.each(_.flatten([modelAttr]), function(attr) {
+            observeModelEvent(model, self, 'change:'+attr, function(model, val, options) {
+              if (options == null || options.bindKey != bindKey)
+                updateViewBindEl(self, $el, config, getVal(model, modelAttr, config, self), model);
+            });
+          });
 
-			// Wrap remove so that we can remove model events when this view is removed.
-			this.remove = _.wrap(this.remove, function(oldRemove) {
-				self.unstickModel();
-				if (oldRemove) oldRemove.call(self);
-			});
-		}
-	});
+          updateViewBindEl(self, $el, config, getVal(model, modelAttr, config, self), model, true);
+        }
+      });
 
-	// Helpers
-	// -------
+      // Have Backbone delegate any newly added events in `_stickitEvents`.
+      this.delegateEvents(this._stickitEvents);
 
-	// Evaluates the given `path` (in object/dot-notation) relative to the given `obj`.
-	// If the path is null/undefined, then the given `obj` is returned.
-	var evaluatePath = function(obj, path) {
-		var parts = (path || '').split('.');
-		var result = _.reduce(parts, function(memo, i) { return memo[i]; }, obj);
-		return result == null ? obj : result;
-	};
+      // Wrap remove so that we can remove model events when this view is removed.
+      this.remove = _.wrap(this.remove, function(oldRemove) {
+        self.unstickModel();
+        if (oldRemove) oldRemove.call(self);
+      });
+    }
+  });
 
-	// If the given `fn` is a string, then view[fn] is called, otherwise it is a function
-	// that should be executed.
-	var applyViewFn = function(view, fn) {
-		if (fn) return (_.isString(fn) ? view[fn] : fn).apply(view, _.toArray(arguments).slice(2));
-	};
+  // Helpers
+  // -------
 
-	// Given a function, string (view function reference), or a boolean
-	// value, returns the truthy result. Any other types evaluate as false.
-	var evaluateBoolean = function(view, reference) {
-		if (_.isBoolean(reference)) return reference;
-		else if (_.isFunction(reference) || _.isString(reference))
-			return applyViewFn.apply(this, _.toArray(arguments));
-		return false;
-	};
+  // Evaluates the given `path` (in object/dot-notation) relative to the given `obj`.
+  // If the path is null/undefined, then the given `obj` is returned.
+  var evaluatePath = function(obj, path) {
+    var parts = (path || '').split('.');
+    var result = _.reduce(parts, function(memo, i) { return memo[i]; }, obj);
+    return result == null ? obj : result;
+  };
 
-	// Setup a model event binding with the given function, and track the
-	// event in the view's _modelBindings.
-	var observeModelEvent = function(model, view, event, fn) {
-		model.on(event, fn, view);
-		view._modelBindings.push({model:model, event:event, fn:fn});
-	};
+  // If the given `fn` is a string, then view[fn] is called, otherwise it is a function
+  // that should be executed.
+  var applyViewFn = function(view, fn) {
+    if (fn) return (_.isString(fn) ? view[fn] : fn).apply(view, _.toArray(arguments).slice(2));
+  };
 
-	// Prepares the given value and sets it into the model.
-	var setVal = function(model, attr, val, options, onSet, context) {
-		if (onSet) val = applyViewFn(context, onSet, val, attr);
-		model.set(attr, val, options);
-	};
+  // Given a function, string (view function reference), or a boolean
+  // value, returns the truthy result. Any other types evaluate as false.
+  var evaluateBoolean = function(view, reference) {
+    if (_.isBoolean(reference)) return reference;
+    else if (_.isFunction(reference) || _.isString(reference))
+      return applyViewFn.apply(this, _.toArray(arguments));
+    return false;
+  };
 
-	// Returns the given `field`'s value from the `model`, escaping and formatting if necessary.
-	// If `field` is an array, then an array of respective values will be returned.
-	var getVal = function(model, field, config, context) {
-		var val, retrieveVal = function(attr) {
-			var retrieved = config.escape ? model.escape(attr) : model.get(attr);
-			return _.isUndefined(retrieved) ? '' : retrieved;
-		};
-		val = _.isArray(field) ? _.map(field, retrieveVal) : retrieveVal(field);
-		return config.onGet ? applyViewFn(context, config.onGet, val, field) : val;
-	};
+  // Setup a model event binding with the given function, and track the
+  // event in the view's _modelBindings.
+  var observeModelEvent = function(model, view, event, fn) {
+    model.on(event, fn, view);
+    view._modelBindings.push({model:model, event:event, fn:fn});
+  };
 
-	// Returns the list of events needed to bind to the given form element.
-	var getModelEvents = function($el) {
-		// Binding to `oninput` is off the table since IE9- has buggy to no support, and
-		// using feature detection doesn't work because it is hard to sniff in Firefox.
-		if (isInput($el) || isTextarea($el) || isContenteditable($el))
-			return ['keyup', 'change', 'paste', 'cut'];
-		else return ['change'];
-	};
+  // Prepares the given value and sets it into the model.
+  var setVal = function(model, attr, val, options, onSet, context) {
+    if (onSet) val = applyViewFn(context, onSet, val, attr);
+    model.set(attr, val, options);
+  };
 
-	// Updates the given element according to the rules for the `visible` api key.
-	var updateVisibleBindEl = function($el, val, attrName, config, context) {
-		var visible = config.visible, visibleFn = config.visibleFn, isVisible = !!val;
+  // Returns the given `field`'s value from the `model`, escaping and formatting if necessary.
+  // If `field` is an array, then an array of respective values will be returned.
+  var getVal = function(model, field, config, context) {
+    var val, retrieveVal = function(attr) {
+      var retrieved = config.escape ? model.escape(attr) : model.get(attr);
+      return _.isUndefined(retrieved) ? '' : retrieved;
+    };
+    val = _.isArray(field) ? _.map(field, retrieveVal) : retrieveVal(field);
+    return config.onGet ? applyViewFn(context, config.onGet, val, field) : val;
+  };
 
-		// If `visible` is a function then it should return a boolean result to show/hide.
-		if (_.isFunction(visible) || _.isString(visible)) isVisible = applyViewFn(context, visible, val, attrName);
-		
-		// Either use the custom `visibleFn`, if provided, or execute a standard jQuery show/hide.
-		if (visibleFn) applyViewFn(context, visibleFn, $el, isVisible, attrName);
-		else {
-			if (isVisible) $el.show();
-			else $el.hide();
-		}
-	};
+  // Returns the list of events needed to bind to the given form element.
+  var getModelEvents = function($el) {
+    // Binding to `oninput` is off the table since IE9- has buggy to no support, and
+    // using feature detection doesn't work because it is hard to sniff in Firefox.
+    if (isInput($el) || isTextarea($el) || isContenteditable($el))
+      return ['keyup', 'change', 'paste', 'cut'];
+    else return ['change'];
+  };
 
-	// Update the value of `$el` in `view` using the given configuration.
-	var updateViewBindEl = function(view, $el, config, val, model, isInitializing) {
-		var modelAttr = config.observe || config.modelAttr,
-			afterUpdate = config.afterUpdate,
-			originalVal = Stickit.getElVal($el, (config.updateMethod == 'html' || isContenteditable($el)));
+  // Updates the given element according to the rules for the `visible` api key.
+  var updateVisibleBindEl = function($el, val, attrName, config, context) {
+    var visible = config.visible, visibleFn = config.visibleFn, isVisible = !!val;
 
-		// Don't update the view if `updateView` returns false.
-		if (!evaluateBoolean(view, config.updateView, val)) return;
+    // If `visible` is a function then it should return a boolean result to show/hide.
+    if (_.isFunction(visible) || _.isString(visible)) isVisible = applyViewFn(context, visible, val, attrName);
 
-		Stickit.updateEl($el, val, config);
+    // Either use the custom `visibleFn`, if provided, or execute a standard jQuery show/hide.
+    if (visibleFn) applyViewFn(context, visibleFn, $el, isVisible, attrName);
+    else {
+      if (isVisible) $el.show();
+      else $el.hide();
+    }
+  };
 
-		// Execute the `afterUpdate` callback from the `bindings` config.
-		if (!isInitializing) applyViewFn(view, afterUpdate, $el, val, originalVal);
-	};
+  // Update the value of `$el` in `view` using the given configuration.
+  var updateViewBindEl = function(view, $el, config, val, model, isInitializing) {
+    var modelAttr = config.observe || config.modelAttr,
+      afterUpdate = config.afterUpdate,
+      originalVal = Stickit.getElVal($el, (config.updateMethod == 'html' || isContenteditable($el)));
 
-	var addSelectOptions = function(optList, $el, selectConfig, fieldVal, isMultiple) {
-		_.each(optList, function(obj) {
-			var option = $('<option/>'), optionVal = obj;
+    // Don't update the view if `updateView` returns false.
+    if (!evaluateBoolean(view, config.updateView, val)) return;
 
-			// If the list contains a null/undefined value, then an empty option should
-			// be appended in the list; otherwise, fill the option with text and value.
-			if (obj != null) {
-				option.text(evaluatePath(obj, selectConfig.labelPath || "label"));
-				optionVal = evaluatePath(obj, selectConfig.valuePath || "value");
-			} else if ($el.find('option').length && $el.find('option:eq(0)').data('stickit_bind_val') == null) return false;
+    Stickit.updateEl($el, val, config);
 
-			// Save the option value so that we can reference it later.
-			option.data('stickit_bind_val', optionVal);
+    // Execute the `afterUpdate` callback from the `bindings` config.
+    if (!isInitializing) applyViewFn(view, afterUpdate, $el, val, originalVal);
+  };
 
-			// Determine if this option is selected.
-			if (!isMultiple && optionVal != null && fieldVal != null && optionVal == fieldVal || (_.isObject(fieldVal) && _.isEqual(optionVal, fieldVal)))
-				option.prop('selected', true);
-			else if (isMultiple && _.isArray(fieldVal)) {
-				_.each(fieldVal, function(val) {
-					if (_.isObject(val)) val = evaluatePath(val, selectConfig.valuePath);
-					if (val == optionVal || (_.isObject(val) && _.isEqual(optionVal, val)))
-						option.prop('selected', true);
-				});
-			}
+  var addSelectOptions = function(optList, $el, selectConfig, fieldVal, isMultiple) {
+    _.each(optList, function(obj) {
+      var option = $('<option/>'), optionVal = obj;
 
-			$el.append(option);
-		});
-	};
+      // If the list contains a null/undefined value, then an empty option should
+      // be appended in the list; otherwise, fill the option with text and value.
+      if (obj != null) {
+        option.text(evaluatePath(obj, selectConfig.labelPath || "label"));
+        optionVal = evaluatePath(obj, selectConfig.valuePath || "value");
+      } else if ($el.find('option').length && $el.find('option:eq(0)').data('stickit_bind_val') == null) return false;
+
+      // Save the option value so that we can reference it later.
+      option.data('stickit_bind_val', optionVal);
+
+      // Determine if this option is selected.
+      if (!isMultiple && optionVal != null && fieldVal != null && optionVal == fieldVal || (_.isObject(fieldVal) && _.isEqual(optionVal, fieldVal)))
+        option.prop('selected', true);
+      else if (isMultiple && _.isArray(fieldVal)) {
+        _.each(fieldVal, function(val) {
+          if (_.isObject(val)) val = evaluatePath(val, selectConfig.valuePath);
+          if (val == optionVal || (_.isObject(val) && _.isEqual(optionVal, val)))
+            option.prop('selected', true);
+        });
+      }
+
+      $el.append(option);
+    });
+  };
 
 })(window.jQuery || window.Zepto);

--- a/test/bindData.js
+++ b/test/bindData.js
@@ -1,1181 +1,1181 @@
 $(document).ready(function() {
 
-	module("view.stickit");
-
-	test('input:text', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst1';
-		view.bindings = {
-			'#test1': {
-				observe: 'water'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test1').val(), 'fountain');
-
-		model.set('water', 'evian');
-		equal(view.$('#test1').val(), 'evian');
-		
-		view.$('#test1').val('dasina').keyup();
-		equal(model.get('water'), 'dasina');
-	});
-
-	test('textarea', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst2';
-		view.bindings = {
-			'#test2': {
-				observe: 'water'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test2').val(), 'fountain');
-
-		model.set('water', 'evian');
-		equal(view.$('#test2').val(), 'evian');
-		
-		view.$('#test2').val('dasina').keyup();
-		equal(model.get('water'), 'dasina');
-	});
-
-	test('contenteditable', function() {
-		
-		model.set({'water':'<span>fountain</span>'});
-		view.model = model;
-		view.templateId = 'jst17';
-		view.bindings = {
-			'#test17': {
-				observe: 'water'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test17').html(), '<span>fountain</span>');
-
-		model.set('water', '<span>evian</span>');
-		equal(view.$('#test17').html(), '<span>evian</span>');
-		
-		view.$('#test17').html('<span>dasina</span>').keyup();
-		equal(model.get('water'), '<span>dasina</span>');
-	});
-
-	test('checkbox', function() {
-		
-		model.set({'water':true});
-		view.model = model;
-		view.templateId = 'jst3';
-		view.bindings = {
-			'#test3': {
-				observe: 'water'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test3').prop('checked'), true);
-
-		model.set('water', false);
-		equal(view.$('#test3').prop('checked'), false);
-		
-		view.$('#test3').prop('checked', true).change();
-		equal(model.get('water'), true);
-	});
-
-	test('radio', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst4';
-		view.bindings = {
-			'.test4': {
-				observe: 'water'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('.test4:checked').val(), 'fountain');
-
-		model.set('water', 'evian');
-		equal(view.$('.test4:checked').val(), 'evian');
-		
-		view.$('.test4[value=fountain]').prop('checked', true).change();
-		equal(model.get('water'), 'fountain');
-	});
-
-	test('div', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				observe: 'water'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').text(), 'fountain');
-
-		model.set('water', 'evian');
-		equal(view.$('#test5').text(), 'evian');
-	});
-
-	test(':el selector', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			':el': {
-				observe: 'water'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$el.text(), 'fountain');
-
-		model.set('water', 'evian');
-		equal(view.$el.text(), 'evian');
-	});
-
-	test('stickit (shorthand bindings)', function() {
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': 'water'
-		};
-		$('#qunit-fixture').html(view.render().el);
-		
-		equal(view.$('#test5').text(), 'fountain');
-
-		model.set('water', 'evian');
-
-		equal(view.$('#test5').text(), 'evian');
-
-	});
-
-	test('stickit (multiple models and bindings)', function() {
-	
-		// Test sticking two times to two different models and configs.
-		var model1, model2, testView;
-		
-		model1 = new (Backbone.Model)({id:1, water:'fountain', candy:'twix'});
-		model2 = new (Backbone.Model)({id:2, water:'evian', candy:'snickers'});
-		
-		testView = new (Backbone.View.extend({
-			initialize: function() {
-				this.model = model1;
-				this.otherModel = model2;
-			},
-			bindings: {
-				'#test0-div': {
-					observe: 'water'
-				},
-				'#test0-textarea': {
-					observe: 'candy'
-				}
-			},
-			otherBindings: {
-				'#test0-span': {
-					observe: 'water'
-				},
-				'#test0-input': {
-					observe: 'candy'
-				}
-			},
-			render: function() {
-				var html = document.getElementById('jst0').innerHTML;
-				this.$el.html(_.template(html)());
-				this.stickit();
-				this.stickit(this.otherModel, this.otherBindings);
-				return this;
-			}
-		}))();
-
-		$('#qunit-fixture').html(testView.render().el);
-
-		equal(testView.$('#test0-div').text(), 'fountain');
-		equal(testView.$('#test0-textarea').val(), 'twix');
-		equal(testView.$('#test0-span').text(), 'evian');
-		equal(testView.$('#test0-input').val(), 'snickers');
-
-		model1.set({water:'dasina', candy: 'mounds'});
-		model2.set({water:'poland springs', candy: 'almond joy'});
-
-		equal(testView.$('#test0-div').text(), 'dasina');
-		equal(testView.$('#test0-textarea').val(), 'mounds');
-		equal(testView.$('#test0-span').text(), 'poland springs');
-		equal(testView.$('#test0-input').val(), 'almond joy');
-
-		testView.$('#test0-textarea').val('kit kat').keyup();
-		testView.$('#test0-input').val('butterfinger').keyup();
-
-		equal(model1.get('candy'), 'kit kat');
-		equal(model2.get('candy'), 'butterfinger');
-	});
-
-	test('stickit (existing events property as hash with multiple models and bindings)', function() {
-
-		var model1, testView;
-
-		model1 = new (Backbone.Model)({id:1, candy:'twix' });
-		model2 = new (Backbone.Model)({id:2, candy:'snickers'});
-
-		testView = new (Backbone.View.extend({
-
-			initialize: function() {
-				this.model = model1;
-				this.otherModel = model2;
-			},
-
-			events: {
-				click: 'handleClick'
-			},
-
-			bindings: {
-				'#test0-textarea': 'candy'
-			},
-
-			otherBindings: {
-				'#test0-input': 'candy'
-			},
-
-			render: function() {
-				var html = document.getElementById('jst0').innerHTML;
-				this.$el.html(_.template(html)());
-				this.stickit();
-				this.stickit(this.otherModel, this.otherBindings);
-				return this;
-			},
-
-			handleClick: function() {
-				this.clickHandled = true;
-			}
-
-		}))();
-
-		$('#qunit-fixture').html(testView.render().el);
-
-		testView.$('#test0-textarea').val('kit kat').keyup();
-		testView.$('#test0-input').val('butterfinger').keyup();
-
-		equal(model1.get('candy'), 'kit kat');
-		equal(model2.get('candy'), 'butterfinger');
-
-		testView.$el.click();
-
-		equal(testView.clickHandled, true);
-
-	});
-
-	test('stickit (existing events property as function with multiple models and bindings)', function() {
-
-		var model1, testView;
-
-		model1 = new (Backbone.Model)({id:1, candy:'twix' });
-		model2 = new (Backbone.Model)({id:2, candy:'snickers'});
-
-		testView = new (Backbone.View.extend({
-
-			initialize: function() {
-				this.model = model1;
-				this.otherModel = model2;
-			},
-
-			events: function() {
-
-				var self = this;
-
-				return {
-					click: function() {
-						self.clickHandled = true;
-					}
-				};
-
-			},
-
-			bindings: {
-				'#test0-textarea': 'candy'
-			},
-
-			otherBindings: {
-				'#test0-input': 'candy'
-			},
-
-			render: function() {
-				var html = document.getElementById('jst0').innerHTML;
-				this.$el.html(_.template(html)());
-				this.stickit();
-				this.stickit(this.otherModel, this.otherBindings);
-				return this;
-			}
-
-		}))();
-
-		$('#qunit-fixture').html(testView.render().el);
-
-		testView.$('#test0-textarea').val('kit kat').keyup();
-		testView.$('#test0-input').val('butterfinger').keyup();
-
-		equal(model1.get('candy'), 'kit kat');
-		equal(model2.get('candy'), 'butterfinger');
-
-		testView.$el.click();
-
-		equal(testView.clickHandled, true);
-
-	});
-
-	test('bindings:setOptions', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst1';
-		view.bindings = {
-			'#test1': {
-				observe: 'water',
-				setOptions: {silent:true}
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test1').val(), 'fountain');
-		
-		view.$('#test1').val('dasina').keyup();
-		equal(model.get('water'), 'dasina');
-		equal(model.changedAttributes().water, 'dasina');
-	});
-
-	test('bindings:updateMethod', function() {
-		
-		model.set({'water':'<a href="www.test.com">river</a>'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				observe: 'water',
-				updateMethod: 'html'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').text(), 'river');
-	});
-
-	test('bindings:escape', function() {
-		
-		model.set({'water':'<a href="www.test.com">river</a>'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				observe: 'water',
-				updateMethod: 'html',
-				escape: true
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').text(), '<a href="www.test.com">river</a>');
-	});
-
-	test('bindings:format', 3, function() {
-
-		// Deprecated version of `onget`.
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				observe: 'water',
-				format: function(val, modelAttr) {
-					equal(val, this.model.get('water'));
-					equal(modelAttr, 'water');
-					return '_' + val + '_' + modelAttr;
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').text(), '_fountain_water');
-	});
-
-	test('bindings:onSet/onGet', 6, function() {
-		
-		model.set({'water':'_fountain'});
-		view.model = model;
-		view.templateId = 'jst1';
-		view.bindings = {
-			'#test1': {
-				observe: 'water',
-				onGet: function(val, modelAttr) {
-					equal(val, this.model.get('water'));
-					equal(modelAttr, 'water');
-					return val.substring(1);
-				},
-				onSet: function(val, modelAttr) {
-					equal(val, view.$('#test1').val());
-					equal(modelAttr, 'water');
-					return '_' + val;
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test1').val(), 'fountain');
-		view.$('#test1').val('evian').keyup();
-		equal(model.get('water'), '_evian');
-	});
-
-	test('bindings:afterUpdate', function() {
-		
-		model.set({'water':'fountain', 'candy':true});
-		view.model = model;
-		view.templateId = 'jst15';
-		view.bindings = {
-			'#test15-1': {
-				observe: 'water',
-				afterUpdate: function($el, val, originalVal) {
-					equal($el.text(), model.get('water'));
-					equal(val, 'evian');
-					equal(originalVal, 'fountain');
-				}
-			},
-			'#test15-2': {
-				observe: 'water',
-				afterUpdate: function($el, val, originalVal) {
-					equal($el.val(), model.get('water'));
-					equal(val, 'evian');
-					equal(originalVal, 'fountain');
-				}
-			},
-			'#test15-3': {
-				observe: 'candy',
-				afterUpdate: function($el, val, originalVal) {
-					equal(val, false);
-					equal(originalVal, true);
-				}
-			},
-			'.test15-4': {
-				observe: 'water',
-				afterUpdate: function($el, val, originalVal) {
-					equal(val, 'evian');
-					equal(originalVal, 'fountain');
-				}
-			},
-			'#test15-6': {
-				observe: 'water',
-				afterUpdate: function($el, val, originalVal) {
-					equal(val, 'evian');
-					equal(originalVal, 'fountain');
-				}
-			},
-			'#test15-7': {
-				observe: 'water',
-				selectOptions: {
-					collection: function() { return [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}]; },
-					labelPath: 'name',
-					valuePath: 'name'
-				},
-				afterUpdate: function($el, val, originalVal) {
-					equal(val, 'evian');
-					equal(originalVal, 'fountain');
-				}
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		model.set('water', 'evian');
-		model.set('candy', false);
-	});
-
-	test('bindings:selectOptions', function() {
-
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst8';
-		view.bindings = {
-			'#test8': {
-				observe: 'water',
-				selectOptions: {
-					collection: function() { return [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}]; },
-					labelPath: 'name',
-					valuePath: 'name'
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'fountain');
-
-		model.set('water', 'evian');
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'evian');
-		
-		view.$('#test8 option:eq(2)').prop('selected', true).change();
-		equal(model.get('water'), 'dasina');
-	});
-	
-	test('bindings:selectOptions (empty valuePath)', function() {
-	
-		model.set({'water':{id:1, name:'fountain'}});
-		window.test = {
-			collection: [null, {id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}]
-		};
-		view.model = model;
-		view.templateId = 'jst8';
-		view.bindings = {
-			'#test8': {
-				observe: 'water',
-				selectOptions: {
-					collection: 'test.collection',
-					labelPath: 'name'
-				}
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test8 option:selected').data('stickit_bind_val').id, 1);
-
-		model.set('water', {id:2, name:'evian'});
-		equal(view.$('#test8 option:selected').data('stickit_bind_val').id, 2);
-
-		view.$('#test8 option:eq(3)').prop('selected', true).change();
-		equal(model.get('water').id, 3);
-	});
-	
-	test('bindings:selectOptions (null model val - empty option)', function() {
-	
-		model.set({'water':null});
-		window.test = {
-			collection: [null, {id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}]
-		};
-		view.model = model;
-		view.templateId = 'jst8';
-		view.bindings = {
-			'#test8': {
-				observe: 'water',
-				selectOptions: {
-					collection: 'test.collection',
-					labelPath: 'name'
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), null);
-
-		model.set('water', {id:2, name:'evian'});
-		equal(view.$('#test8 option:selected').data('stickit_bind_val').id, 2);
-		
-		view.$('#test8 option:eq(0)').prop('selected', true).change();
-		equal(model.get('water'), null);
-	});
-
-	test('bindings:selectOptions (empty string label)', function() {
-	
-		model.set({'water':'session'});
-		view.model = model;
-		view.templateId = 'jst8';
-		view.bindings = {
-			'#test8': {
-				observe: 'water',
-				selectOptions: {
-					collection: function() {
-						return [{label:'c',value:''}, {label:'s',value:'session'}];
-					},
-					labelPath: "label",
-					valuePath: "value"
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'session');
-		equal(view.$('#test8 option:eq(0)').data('stickit_bind_val'), '');
-
-		model.set('water', '');
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), '');
-	});
-
-	test('bindings:selectOptions (default labelPath/valuePath)', function() {
-	
-		model.set({'water':'evian'});
-		view.model = model;
-		view.templateId = 'jst8';
-		view.bindings = {
-			'#test8': {
-				observe: 'water',
-				selectOptions: {
-					collection: function() {
-						return [{label:'c',value:'fountain'}, {label:'s',value:'evian'}];
-					}
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'evian');
-
-		model.set('water', 'fountain');
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'fountain');
-	});
-
-	test('bindings:selectOptions (multi-select without valuePath)', function() {
-
-		var collection = [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}, {id:4,name:'aquafina'}];
-		
-		model.set({'water': [{id:1,name:'fountain'}, {id:3,name:'dasina'}] });
-		view.model = model;
-		view.templateId = 'jst16';
-		view.bindings = {
-			'#test16': {
-				observe: 'water',
-				selectOptions: {
-					collection: function() { return collection; },
-					labelPath: 'name'
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test16 option:selected:eq(0)').data('stickit_bind_val').name, 'fountain');
-		equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val').name, 'dasina');
-
-		var field = _.clone(model.get('water'));
-		field.push({id:2,name:'evian'});
-
-		model.set({'water':field});
-		equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val').name, 'evian');
-
-		view.$('#test16 option:eq(3)').prop('selected', true).change();
-
-		equal(model.get('water').length, 4);
-
-	});
-
-	test('bindings:selectOptions (multi-select with valuePath)', function() {
-
-		var collection = [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}, {id:4,name:'aquafina'}];
-		
-		model.set({'water': [1, 3]});
-		view.model = model;
-		view.templateId = 'jst16';
-		view.bindings = {
-			'#test16': {
-				observe: 'water',
-				selectOptions: {
-					collection: function() { return collection; },
-					labelPath: 'name',
-					valuePath: 'id'
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test16 option:selected:eq(0)').data('stickit_bind_val'), 1);
-		equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val'), 3);
-
-		var field = _.clone(model.get('water'));
-		field.push(2);
-
-		model.set({'water':field});
-		equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val'), 2);
-
-		view.$('#test16 option:eq(3)').prop('selected', true).change();
-
-		equal(model.get('water').length, 4);
-
-	});
-
-	test('bindings:selectOptions (multi-select with onGet/onSet)', function() {
-
-		var collection = [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}, {id:4,name:'aquafina'}];
-		
-		model.set({'water':'1-3'});
-		view.model = model;
-		view.templateId = 'jst16';
-		view.bindings = {
-			'#test16': {
-				observe: 'water',
-				onGet: function(val, attr) {
-					return _.map(val.split('-'), function(id) {return Number(id);});
-				},
-				onSet: function(vals, attr) {
-					return vals.join('-');
-				},
-				selectOptions: {
-					collection: function() { return collection; },
-					labelPath: 'name',
-					valuePath: 'id'
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test16 option:selected:eq(0)').data('stickit_bind_val'), 1);
-		equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val'), 3);
-
-		var field = _.clone(model.get('water'));
-		field += '-2';
-
-		model.set({'water':field});
-		equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val'), 2);
-
-		view.$('#test16 option:eq(3)').prop('selected', true).change();
-
-		equal(model.get('water'), '1-2-3-4');
-
-	});
-
-	test('bindings:selectOptions (optgroup)', function() {
-
-		model.set({'character':3});
-		view.model = model;
-		view.templateId = 'jst8';
-		view.bindings = {
-			'#test8': {
-				observe: 'character',
-				selectOptions: {
-					collection: function() {
-						return {
-							'opt_labels': ['Looney Tunes', 'Three Stooges'],
-							'Looney Tunes': [{id: 1, name: 'Bugs Bunny'}, {id: 2, name: 'Donald Duck'}],
-							'Three Stooges': [{id: 3, name : 'moe'}, {id: 4, name : 'larry'}, {id: 5, name : 'curly'}]
-						};
-					},
-					labelPath: 'name',
-					valuePath: 'id'
-				}
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test8 option:selected').parent().is('optgroup'), true);
-		equal(view.$('#test8 option:selected').parent().attr('label'), 'Three Stooges');
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), 3);
-
-		model.set({'character':2});
-		equal(view.$('#test8 option:selected').data('stickit_bind_val'), 2);
-
-		view.$('#test8 option:eq(3)').prop('selected', true).change();
-		equal(model.get('character'), 4);
-	});
-
-	test('bindings:attributes:name', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				observe: 'water',
-				attributes: [{
-					name: 'data-name'
-
-				}]
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').attr('data-name'), 'fountain');
-
-		model.set('water', 'evian');
-		equal(view.$('#test5').attr('data-name'), 'evian');
-	});
-
-	test('bindings:attributes:name:class', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst9';
-		view.bindings = {
-			'#test9': {
-				observe: 'water',
-				attributes: [{
-					name: 'class'
-				}]
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		ok(view.$('#test9').hasClass('test') && view.$('#test9').hasClass('fountain'));
-
-		model.set('water', 'evian');
-		ok(view.$('#test9').hasClass('test') && view.$('#test9').hasClass('evian'));
-	});
-
-	test('bindings:attributes:format', function() {
-		
-		// Deprecated version of `onGet`
-
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				observe: 'water',
-				attributes: [{
-					name: 'data-name',
-					format: function(val, modelAttr) { return '_' + val + '_' + modelAttr; }
-				}]
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').attr('data-name'), '_fountain_water');
-
-		model.set('water', 'evian');
-		equal(view.$('#test5').attr('data-name'), '_evian_water');
-	});
-
-	test('bindings:attributes:onGet', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				observe: 'water',
-				attributes: [{
-					name: 'data-name',
-					onGet: function(val, modelAttr) { return '_' + val + '_' + modelAttr; }
-				}]
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').attr('data-name'), '_fountain_water');
-
-		model.set('water', 'evian');
-		equal(view.$('#test5').attr('data-name'), '_evian_water');
-	});
-
-	test('bindings:attributes:observe', function() {
-		
-		model.set({'water':'fountain', 'candy':'twix'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				attributes: [{
-					name: 'data-name',
-					observe: 'candy',
-					onGet: function(val) {
-						equal(val, this.model.get('candy'));
-						return this.model.get('water') + '-' + this.model.get('candy');
-					}
-				}]
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').attr('data-name'), 'fountain-twix');
-
-		model.set({'water':'evian', 'candy':'snickers'});
-		equal(view.$('#test5').attr('data-name'), 'evian-snickers');
-	});
-
-	test('bindings:attributes:observe (array)', 11, function() {
-		
-		model.set({'water':'fountain', 'candy':'twix'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				attributes: [{
-					name: 'data-name',
-					observe: ['water', 'candy'],
-					onGet: function(val, modelAttr) {
-						_.each(modelAttr, _.bind(function(attr, i) {
-							equal(val[i], this.model.get(attr));
-						}, this));
-						equal(modelAttr.toString(), 'water,candy');
-						return model.get('water') + '-' + model.get('candy');
-					}
-				}]
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').attr('data-name'), 'fountain-twix');
-
-		model.set({'water':'evian', 'candy':'snickers'});
-		equal(view.$('#test5').attr('data-name'), 'evian-snickers');
-	});
-
-	test('bindings:attributes (properties)', function() {
-		
-		model.set({'water':true});
-		view.model = model;
-		view.templateId = 'jst1';
-		view.bindings = {
-			'#test1': {
-				attributes: [{
-					name: 'readonly',
-					observe: 'water'
-				}]
-			}
-		};
-
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test1').prop('readonly'), true);
-
-		model.set({'water':false});
-		equal(view.$('#test1').prop('readonly'), false);
-	});
-
-	test('input:number', function() {
-		
-		model.set({'code':1});
-		view.model = model;
-		view.templateId = 'jst11';
-		view.bindings = {
-			'#test11': {
-				observe: 'code'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(Number(view.$('#test11').val()), 1);
-
-		model.set('code', 2);
-		equal(Number(view.$('#test11').val()), 2);
-	});
-
-	test('visible', 16, function() {
-		
-		model.set({'water':false, 'candy':'twix', 'costume':false});
-		view.model = model;
-		view.templateId = 'jst14';
-		view.bindings = {
-			'#test14-1': {
-				observe: 'water',
-				visible: true
-			},
-			'#test14-2': {
-				observe: 'candy',
-				visible: function(val, attrName) {
-					equal(val, this.model.get('candy'));
-					equal(attrName, 'candy');
-					return this.model.get('candy') == 'twix';
-				}
-			},
-			'#test14-3': {
-				observe: 'costume',
-				visible: true,
-				visibleFn: function($el, val, attrName) {
-					equal($el.attr('id'), 'test14-3');
-					equal(val, this.model.get('costume'));
-					equal(attrName, 'costume');
-				}
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test14-1').css('display') == 'block' , false);
-		equal(view.$('#test14-2').css('display') == 'block' , true);
-		equal(view.$('#test14-3').css('display') == 'block' , true);
-
-		model.set('water', true);
-		model.set('candy', 'snickers');
-		model.set('costume', true);
-		
-		equal(view.$('#test14-1').css('display') == 'block' , true);
-		equal(view.$('#test14-2').css('display') == 'block' , false);
-		equal(view.$('#test14-3').css('display') == 'block' , true);
-	});
-
-	test('observe (multiple; array)', 12, function() {
-		
-		model.set({'water':'fountain', 'candy':'twix'});
-		view.model = model;
-		view.templateId = 'jst5';
-		view.bindings = {
-			'#test5': {
-				observe: ['water', 'candy'],
-				onGet: function(val, modelAttr) {
-					_.each(modelAttr, _.bind(function(attr, i) {
-						equal(val[i], this.model.get(attr));
-					}, this));
-					equal(modelAttr.toString(), 'water,candy');
-					return model.get('water') + ' ' + model.get('candy');
-				}
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test5').text(), 'fountain twix');
-
-		model.set('water', 'evian');
-		equal(view.$('#test5').text(), 'evian twix');
-
-		model.set('candy', 'snickers');
-		equal(view.$('#test5').text(), 'evian snickers');
-	});
-
-	test('bindings:updateView', 6, function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst1';
-		view.bindings = {
-			'#test1': {
-				observe: 'water',
-				updateView: function(val) {
-					equal(val, model.get('water'));
-					return val == 'evian';
-				}
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test1').val(), '');
-
-		model.set({water:'evian'});
-		equal(view.$('#test1').val(), 'evian');
-
-		model.set({water:'dasina'});
-		equal(view.$('#test1').val(), 'evian');
-	});
-
-	test('bindings:updateModel', 6, function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst1';
-		view.bindings = {
-			'#test1': {
-				observe: 'water',
-				updateModel: function(val, attrName) {
-					equal(val, view.$('#test1').val());
-					equal(attrName, 'water');
-					return val == 'evian';
-				}
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		view.$('#test1').val('dasina').keyup();
-		equal(model.get('water'), 'fountain');
-
-		view.$('#test1').val('evian').keyup();
-		equal(model.get('water'), 'evian');
-	});
-
-	test('bindings:eventsOverride', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst1';
-		view.bindings = {
-			'#test1': {
-				observe: 'water',
-				eventsOverride: ['blur', 'keydown']
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test1').val(), 'fountain');
-
-		// keyup should be overriden, so no change...
-		view.$('#test1').val('dasina').keyup();
-		equal(model.get('water'), 'fountain');
-
-		view.$('#test1').blur();
-		equal(model.get('water'), 'dasina');
-
-		view.$('#test1').val('evian').keydown();
-		equal(model.get('water'), 'evian');
-	});
-
-	test('bindings:modelAttr (deprecated)', function() {
-		
-		model.set({'water':'fountain'});
-		view.model = model;
-		view.templateId = 'jst1';
-		view.bindings = {
-			'#test1': {
-				modelAttr: 'water'
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('#test1').val(), 'fountain');
-
-		model.set('water', 'evian');
-		equal(view.$('#test1').val(), 'evian');
-		
-		view.$('#test1').val('dasina').keyup();
-		equal(model.get('water'), 'dasina');
-	});
-
-	test('checkbox multiple', function() {
-		
-		model.set({'water':['fountain', 'dasina']});
-		view.model = model;
-		view.templateId = 'jst18';
-		view.bindings = {
-			'.boxes': 'water'
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('.boxes[value="fountain"]').prop('checked'), true);
-		equal(view.$('.boxes[value="evian"]').prop('checked'), false);
-		equal(view.$('.boxes[value="dasina"]').prop('checked'), true);
-
-		model.set('water', ['evian']);
-		equal(view.$('.boxes[value="fountain"]').prop('checked'), false);
-		equal(view.$('.boxes[value="evian"]').prop('checked'), true);
-		equal(view.$('.boxes[value="dasina"]').prop('checked'), false);
-		
-		view.$('.boxes[value="dasina"]').prop('checked', true).change();
-		equal(model.get('water').length, 2);
-		equal(_.indexOf(model.get('water'), 'evian') > -1, true);
-		equal(_.indexOf(model.get('water'), 'dasina') > -1, true);
-	});
-
-	test('checkbox (single with value defined)', function() {
-		
-		model.set({'water':null});
-		view.model = model;
-		view.templateId = 'jst19';
-		view.bindings = {
-			'.box': 'water'
-		};
-		$('#qunit-fixture').html(view.render().el);
-
-		equal(view.$('.box').prop('checked'), false);
-		
-		model.set('water', 'fountain');
-		equal(view.$('.box').prop('checked'), true);
-		
-		view.$('.box').prop('checked', false).change();
-		equal(model.get('water'), null);
-	});
+  module("view.stickit");
+
+  test('input:text', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst1';
+    view.bindings = {
+      '#test1': {
+        observe: 'water'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test1').val(), 'fountain');
+
+    model.set('water', 'evian');
+    equal(view.$('#test1').val(), 'evian');
+
+    view.$('#test1').val('dasina').keyup();
+    equal(model.get('water'), 'dasina');
+  });
+
+  test('textarea', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst2';
+    view.bindings = {
+      '#test2': {
+        observe: 'water'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test2').val(), 'fountain');
+
+    model.set('water', 'evian');
+    equal(view.$('#test2').val(), 'evian');
+
+    view.$('#test2').val('dasina').keyup();
+    equal(model.get('water'), 'dasina');
+  });
+
+  test('contenteditable', function() {
+
+    model.set({'water':'<span>fountain</span>'});
+    view.model = model;
+    view.templateId = 'jst17';
+    view.bindings = {
+      '#test17': {
+        observe: 'water'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test17').html(), '<span>fountain</span>');
+
+    model.set('water', '<span>evian</span>');
+    equal(view.$('#test17').html(), '<span>evian</span>');
+
+    view.$('#test17').html('<span>dasina</span>').keyup();
+    equal(model.get('water'), '<span>dasina</span>');
+  });
+
+  test('checkbox', function() {
+
+    model.set({'water':true});
+    view.model = model;
+    view.templateId = 'jst3';
+    view.bindings = {
+      '#test3': {
+        observe: 'water'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test3').prop('checked'), true);
+
+    model.set('water', false);
+    equal(view.$('#test3').prop('checked'), false);
+
+    view.$('#test3').prop('checked', true).change();
+    equal(model.get('water'), true);
+  });
+
+  test('radio', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst4';
+    view.bindings = {
+      '.test4': {
+        observe: 'water'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('.test4:checked').val(), 'fountain');
+
+    model.set('water', 'evian');
+    equal(view.$('.test4:checked').val(), 'evian');
+
+    view.$('.test4[value=fountain]').prop('checked', true).change();
+    equal(model.get('water'), 'fountain');
+  });
+
+  test('div', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        observe: 'water'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').text(), 'fountain');
+
+    model.set('water', 'evian');
+    equal(view.$('#test5').text(), 'evian');
+  });
+
+  test(':el selector', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      ':el': {
+        observe: 'water'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$el.text(), 'fountain');
+
+    model.set('water', 'evian');
+    equal(view.$el.text(), 'evian');
+  });
+
+  test('stickit (shorthand bindings)', function() {
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': 'water'
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').text(), 'fountain');
+
+    model.set('water', 'evian');
+
+    equal(view.$('#test5').text(), 'evian');
+
+  });
+
+  test('stickit (multiple models and bindings)', function() {
+
+    // Test sticking two times to two different models and configs.
+    var model1, model2, testView;
+
+    model1 = new (Backbone.Model)({id:1, water:'fountain', candy:'twix'});
+    model2 = new (Backbone.Model)({id:2, water:'evian', candy:'snickers'});
+
+    testView = new (Backbone.View.extend({
+      initialize: function() {
+        this.model = model1;
+        this.otherModel = model2;
+      },
+      bindings: {
+        '#test0-div': {
+          observe: 'water'
+        },
+        '#test0-textarea': {
+          observe: 'candy'
+        }
+      },
+      otherBindings: {
+        '#test0-span': {
+          observe: 'water'
+        },
+        '#test0-input': {
+          observe: 'candy'
+        }
+      },
+      render: function() {
+        var html = document.getElementById('jst0').innerHTML;
+        this.$el.html(_.template(html)());
+        this.stickit();
+        this.stickit(this.otherModel, this.otherBindings);
+        return this;
+      }
+    }))();
+
+    $('#qunit-fixture').html(testView.render().el);
+
+    equal(testView.$('#test0-div').text(), 'fountain');
+    equal(testView.$('#test0-textarea').val(), 'twix');
+    equal(testView.$('#test0-span').text(), 'evian');
+    equal(testView.$('#test0-input').val(), 'snickers');
+
+    model1.set({water:'dasina', candy: 'mounds'});
+    model2.set({water:'poland springs', candy: 'almond joy'});
+
+    equal(testView.$('#test0-div').text(), 'dasina');
+    equal(testView.$('#test0-textarea').val(), 'mounds');
+    equal(testView.$('#test0-span').text(), 'poland springs');
+    equal(testView.$('#test0-input').val(), 'almond joy');
+
+    testView.$('#test0-textarea').val('kit kat').keyup();
+    testView.$('#test0-input').val('butterfinger').keyup();
+
+    equal(model1.get('candy'), 'kit kat');
+    equal(model2.get('candy'), 'butterfinger');
+  });
+
+  test('stickit (existing events property as hash with multiple models and bindings)', function() {
+
+    var model1, testView;
+
+    model1 = new (Backbone.Model)({id:1, candy:'twix' });
+    model2 = new (Backbone.Model)({id:2, candy:'snickers'});
+
+    testView = new (Backbone.View.extend({
+
+      initialize: function() {
+        this.model = model1;
+        this.otherModel = model2;
+      },
+
+      events: {
+        click: 'handleClick'
+      },
+
+      bindings: {
+        '#test0-textarea': 'candy'
+      },
+
+      otherBindings: {
+        '#test0-input': 'candy'
+      },
+
+      render: function() {
+        var html = document.getElementById('jst0').innerHTML;
+        this.$el.html(_.template(html)());
+        this.stickit();
+        this.stickit(this.otherModel, this.otherBindings);
+        return this;
+      },
+
+      handleClick: function() {
+        this.clickHandled = true;
+      }
+
+    }))();
+
+    $('#qunit-fixture').html(testView.render().el);
+
+    testView.$('#test0-textarea').val('kit kat').keyup();
+    testView.$('#test0-input').val('butterfinger').keyup();
+
+    equal(model1.get('candy'), 'kit kat');
+    equal(model2.get('candy'), 'butterfinger');
+
+    testView.$el.click();
+
+    equal(testView.clickHandled, true);
+
+  });
+
+  test('stickit (existing events property as function with multiple models and bindings)', function() {
+
+    var model1, testView;
+
+    model1 = new (Backbone.Model)({id:1, candy:'twix' });
+    model2 = new (Backbone.Model)({id:2, candy:'snickers'});
+
+    testView = new (Backbone.View.extend({
+
+      initialize: function() {
+        this.model = model1;
+        this.otherModel = model2;
+      },
+
+      events: function() {
+
+        var self = this;
+
+        return {
+          click: function() {
+            self.clickHandled = true;
+          }
+        };
+
+      },
+
+      bindings: {
+        '#test0-textarea': 'candy'
+      },
+
+      otherBindings: {
+        '#test0-input': 'candy'
+      },
+
+      render: function() {
+        var html = document.getElementById('jst0').innerHTML;
+        this.$el.html(_.template(html)());
+        this.stickit();
+        this.stickit(this.otherModel, this.otherBindings);
+        return this;
+      }
+
+    }))();
+
+    $('#qunit-fixture').html(testView.render().el);
+
+    testView.$('#test0-textarea').val('kit kat').keyup();
+    testView.$('#test0-input').val('butterfinger').keyup();
+
+    equal(model1.get('candy'), 'kit kat');
+    equal(model2.get('candy'), 'butterfinger');
+
+    testView.$el.click();
+
+    equal(testView.clickHandled, true);
+
+  });
+
+  test('bindings:setOptions', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst1';
+    view.bindings = {
+      '#test1': {
+        observe: 'water',
+        setOptions: {silent:true}
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test1').val(), 'fountain');
+
+    view.$('#test1').val('dasina').keyup();
+    equal(model.get('water'), 'dasina');
+    equal(model.changedAttributes().water, 'dasina');
+  });
+
+  test('bindings:updateMethod', function() {
+
+    model.set({'water':'<a href="www.test.com">river</a>'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        observe: 'water',
+        updateMethod: 'html'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').text(), 'river');
+  });
+
+  test('bindings:escape', function() {
+
+    model.set({'water':'<a href="www.test.com">river</a>'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        observe: 'water',
+        updateMethod: 'html',
+        escape: true
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').text(), '<a href="www.test.com">river</a>');
+  });
+
+  test('bindings:format', 3, function() {
+
+    // Deprecated version of `onget`.
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        observe: 'water',
+        format: function(val, modelAttr) {
+          equal(val, this.model.get('water'));
+          equal(modelAttr, 'water');
+          return '_' + val + '_' + modelAttr;
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').text(), '_fountain_water');
+  });
+
+  test('bindings:onSet/onGet', 6, function() {
+
+    model.set({'water':'_fountain'});
+    view.model = model;
+    view.templateId = 'jst1';
+    view.bindings = {
+      '#test1': {
+        observe: 'water',
+        onGet: function(val, modelAttr) {
+          equal(val, this.model.get('water'));
+          equal(modelAttr, 'water');
+          return val.substring(1);
+        },
+        onSet: function(val, modelAttr) {
+          equal(val, view.$('#test1').val());
+          equal(modelAttr, 'water');
+          return '_' + val;
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test1').val(), 'fountain');
+    view.$('#test1').val('evian').keyup();
+    equal(model.get('water'), '_evian');
+  });
+
+  test('bindings:afterUpdate', function() {
+
+    model.set({'water':'fountain', 'candy':true});
+    view.model = model;
+    view.templateId = 'jst15';
+    view.bindings = {
+      '#test15-1': {
+        observe: 'water',
+        afterUpdate: function($el, val, originalVal) {
+          equal($el.text(), model.get('water'));
+          equal(val, 'evian');
+          equal(originalVal, 'fountain');
+        }
+      },
+      '#test15-2': {
+        observe: 'water',
+        afterUpdate: function($el, val, originalVal) {
+          equal($el.val(), model.get('water'));
+          equal(val, 'evian');
+          equal(originalVal, 'fountain');
+        }
+      },
+      '#test15-3': {
+        observe: 'candy',
+        afterUpdate: function($el, val, originalVal) {
+          equal(val, false);
+          equal(originalVal, true);
+        }
+      },
+      '.test15-4': {
+        observe: 'water',
+        afterUpdate: function($el, val, originalVal) {
+          equal(val, 'evian');
+          equal(originalVal, 'fountain');
+        }
+      },
+      '#test15-6': {
+        observe: 'water',
+        afterUpdate: function($el, val, originalVal) {
+          equal(val, 'evian');
+          equal(originalVal, 'fountain');
+        }
+      },
+      '#test15-7': {
+        observe: 'water',
+        selectOptions: {
+          collection: function() { return [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}]; },
+          labelPath: 'name',
+          valuePath: 'name'
+        },
+        afterUpdate: function($el, val, originalVal) {
+          equal(val, 'evian');
+          equal(originalVal, 'fountain');
+        }
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    model.set('water', 'evian');
+    model.set('candy', false);
+  });
+
+  test('bindings:selectOptions', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'water',
+        selectOptions: {
+          collection: function() { return [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}]; },
+          labelPath: 'name',
+          valuePath: 'name'
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'fountain');
+
+    model.set('water', 'evian');
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'evian');
+
+    view.$('#test8 option:eq(2)').prop('selected', true).change();
+    equal(model.get('water'), 'dasina');
+  });
+
+  test('bindings:selectOptions (empty valuePath)', function() {
+
+    model.set({'water':{id:1, name:'fountain'}});
+    window.test = {
+      collection: [null, {id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}]
+    };
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'water',
+        selectOptions: {
+          collection: 'test.collection',
+          labelPath: 'name'
+        }
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test8 option:selected').data('stickit_bind_val').id, 1);
+
+    model.set('water', {id:2, name:'evian'});
+    equal(view.$('#test8 option:selected').data('stickit_bind_val').id, 2);
+
+    view.$('#test8 option:eq(3)').prop('selected', true).change();
+    equal(model.get('water').id, 3);
+  });
+
+  test('bindings:selectOptions (null model val - empty option)', function() {
+
+    model.set({'water':null});
+    window.test = {
+      collection: [null, {id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}]
+    };
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'water',
+        selectOptions: {
+          collection: 'test.collection',
+          labelPath: 'name'
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), null);
+
+    model.set('water', {id:2, name:'evian'});
+    equal(view.$('#test8 option:selected').data('stickit_bind_val').id, 2);
+
+    view.$('#test8 option:eq(0)').prop('selected', true).change();
+    equal(model.get('water'), null);
+  });
+
+  test('bindings:selectOptions (empty string label)', function() {
+
+    model.set({'water':'session'});
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'water',
+        selectOptions: {
+          collection: function() {
+            return [{label:'c',value:''}, {label:'s',value:'session'}];
+          },
+          labelPath: "label",
+          valuePath: "value"
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'session');
+    equal(view.$('#test8 option:eq(0)').data('stickit_bind_val'), '');
+
+    model.set('water', '');
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), '');
+  });
+
+  test('bindings:selectOptions (default labelPath/valuePath)', function() {
+
+    model.set({'water':'evian'});
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'water',
+        selectOptions: {
+          collection: function() {
+            return [{label:'c',value:'fountain'}, {label:'s',value:'evian'}];
+          }
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'evian');
+
+    model.set('water', 'fountain');
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), 'fountain');
+  });
+
+  test('bindings:selectOptions (multi-select without valuePath)', function() {
+
+    var collection = [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}, {id:4,name:'aquafina'}];
+
+    model.set({'water': [{id:1,name:'fountain'}, {id:3,name:'dasina'}] });
+    view.model = model;
+    view.templateId = 'jst16';
+    view.bindings = {
+      '#test16': {
+        observe: 'water',
+        selectOptions: {
+          collection: function() { return collection; },
+          labelPath: 'name'
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test16 option:selected:eq(0)').data('stickit_bind_val').name, 'fountain');
+    equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val').name, 'dasina');
+
+    var field = _.clone(model.get('water'));
+    field.push({id:2,name:'evian'});
+
+    model.set({'water':field});
+    equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val').name, 'evian');
+
+    view.$('#test16 option:eq(3)').prop('selected', true).change();
+
+    equal(model.get('water').length, 4);
+
+  });
+
+  test('bindings:selectOptions (multi-select with valuePath)', function() {
+
+    var collection = [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}, {id:4,name:'aquafina'}];
+
+    model.set({'water': [1, 3]});
+    view.model = model;
+    view.templateId = 'jst16';
+    view.bindings = {
+      '#test16': {
+        observe: 'water',
+        selectOptions: {
+          collection: function() { return collection; },
+          labelPath: 'name',
+          valuePath: 'id'
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test16 option:selected:eq(0)').data('stickit_bind_val'), 1);
+    equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val'), 3);
+
+    var field = _.clone(model.get('water'));
+    field.push(2);
+
+    model.set({'water':field});
+    equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val'), 2);
+
+    view.$('#test16 option:eq(3)').prop('selected', true).change();
+
+    equal(model.get('water').length, 4);
+
+  });
+
+  test('bindings:selectOptions (multi-select with onGet/onSet)', function() {
+
+    var collection = [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}, {id:4,name:'aquafina'}];
+
+    model.set({'water':'1-3'});
+    view.model = model;
+    view.templateId = 'jst16';
+    view.bindings = {
+      '#test16': {
+        observe: 'water',
+        onGet: function(val, attr) {
+          return _.map(val.split('-'), function(id) {return Number(id);});
+        },
+        onSet: function(vals, attr) {
+          return vals.join('-');
+        },
+        selectOptions: {
+          collection: function() { return collection; },
+          labelPath: 'name',
+          valuePath: 'id'
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test16 option:selected:eq(0)').data('stickit_bind_val'), 1);
+    equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val'), 3);
+
+    var field = _.clone(model.get('water'));
+    field += '-2';
+
+    model.set({'water':field});
+    equal(view.$('#test16 option:selected:eq(1)').data('stickit_bind_val'), 2);
+
+    view.$('#test16 option:eq(3)').prop('selected', true).change();
+
+    equal(model.get('water'), '1-2-3-4');
+
+  });
+
+  test('bindings:selectOptions (optgroup)', function() {
+
+    model.set({'character':3});
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'character',
+        selectOptions: {
+          collection: function() {
+            return {
+              'opt_labels': ['Looney Tunes', 'Three Stooges'],
+              'Looney Tunes': [{id: 1, name: 'Bugs Bunny'}, {id: 2, name: 'Donald Duck'}],
+              'Three Stooges': [{id: 3, name : 'moe'}, {id: 4, name : 'larry'}, {id: 5, name : 'curly'}]
+            };
+          },
+          labelPath: 'name',
+          valuePath: 'id'
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test8 option:selected').parent().is('optgroup'), true);
+    equal(view.$('#test8 option:selected').parent().attr('label'), 'Three Stooges');
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), 3);
+
+    model.set({'character':2});
+    equal(view.$('#test8 option:selected').data('stickit_bind_val'), 2);
+
+    view.$('#test8 option:eq(3)').prop('selected', true).change();
+    equal(model.get('character'), 4);
+  });
+
+  test('bindings:attributes:name', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        observe: 'water',
+        attributes: [{
+          name: 'data-name'
+
+        }]
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').attr('data-name'), 'fountain');
+
+    model.set('water', 'evian');
+    equal(view.$('#test5').attr('data-name'), 'evian');
+  });
+
+  test('bindings:attributes:name:class', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst9';
+    view.bindings = {
+      '#test9': {
+        observe: 'water',
+        attributes: [{
+          name: 'class'
+        }]
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    ok(view.$('#test9').hasClass('test') && view.$('#test9').hasClass('fountain'));
+
+    model.set('water', 'evian');
+    ok(view.$('#test9').hasClass('test') && view.$('#test9').hasClass('evian'));
+  });
+
+  test('bindings:attributes:format', function() {
+
+    // Deprecated version of `onGet`
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        observe: 'water',
+        attributes: [{
+          name: 'data-name',
+          format: function(val, modelAttr) { return '_' + val + '_' + modelAttr; }
+        }]
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').attr('data-name'), '_fountain_water');
+
+    model.set('water', 'evian');
+    equal(view.$('#test5').attr('data-name'), '_evian_water');
+  });
+
+  test('bindings:attributes:onGet', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        observe: 'water',
+        attributes: [{
+          name: 'data-name',
+          onGet: function(val, modelAttr) { return '_' + val + '_' + modelAttr; }
+        }]
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').attr('data-name'), '_fountain_water');
+
+    model.set('water', 'evian');
+    equal(view.$('#test5').attr('data-name'), '_evian_water');
+  });
+
+  test('bindings:attributes:observe', function() {
+
+    model.set({'water':'fountain', 'candy':'twix'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        attributes: [{
+          name: 'data-name',
+          observe: 'candy',
+          onGet: function(val) {
+            equal(val, this.model.get('candy'));
+            return this.model.get('water') + '-' + this.model.get('candy');
+          }
+        }]
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').attr('data-name'), 'fountain-twix');
+
+    model.set({'water':'evian', 'candy':'snickers'});
+    equal(view.$('#test5').attr('data-name'), 'evian-snickers');
+  });
+
+  test('bindings:attributes:observe (array)', 11, function() {
+
+    model.set({'water':'fountain', 'candy':'twix'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        attributes: [{
+          name: 'data-name',
+          observe: ['water', 'candy'],
+          onGet: function(val, modelAttr) {
+            _.each(modelAttr, _.bind(function(attr, i) {
+              equal(val[i], this.model.get(attr));
+            }, this));
+            equal(modelAttr.toString(), 'water,candy');
+            return model.get('water') + '-' + model.get('candy');
+          }
+        }]
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').attr('data-name'), 'fountain-twix');
+
+    model.set({'water':'evian', 'candy':'snickers'});
+    equal(view.$('#test5').attr('data-name'), 'evian-snickers');
+  });
+
+  test('bindings:attributes (properties)', function() {
+
+    model.set({'water':true});
+    view.model = model;
+    view.templateId = 'jst1';
+    view.bindings = {
+      '#test1': {
+        attributes: [{
+          name: 'readonly',
+          observe: 'water'
+        }]
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test1').prop('readonly'), true);
+
+    model.set({'water':false});
+    equal(view.$('#test1').prop('readonly'), false);
+  });
+
+  test('input:number', function() {
+
+    model.set({'code':1});
+    view.model = model;
+    view.templateId = 'jst11';
+    view.bindings = {
+      '#test11': {
+        observe: 'code'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(Number(view.$('#test11').val()), 1);
+
+    model.set('code', 2);
+    equal(Number(view.$('#test11').val()), 2);
+  });
+
+  test('visible', 16, function() {
+
+    model.set({'water':false, 'candy':'twix', 'costume':false});
+    view.model = model;
+    view.templateId = 'jst14';
+    view.bindings = {
+      '#test14-1': {
+        observe: 'water',
+        visible: true
+      },
+      '#test14-2': {
+        observe: 'candy',
+        visible: function(val, attrName) {
+          equal(val, this.model.get('candy'));
+          equal(attrName, 'candy');
+          return this.model.get('candy') == 'twix';
+        }
+      },
+      '#test14-3': {
+        observe: 'costume',
+        visible: true,
+        visibleFn: function($el, val, attrName) {
+          equal($el.attr('id'), 'test14-3');
+          equal(val, this.model.get('costume'));
+          equal(attrName, 'costume');
+        }
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test14-1').css('display') == 'block' , false);
+    equal(view.$('#test14-2').css('display') == 'block' , true);
+    equal(view.$('#test14-3').css('display') == 'block' , true);
+
+    model.set('water', true);
+    model.set('candy', 'snickers');
+    model.set('costume', true);
+
+    equal(view.$('#test14-1').css('display') == 'block' , true);
+    equal(view.$('#test14-2').css('display') == 'block' , false);
+    equal(view.$('#test14-3').css('display') == 'block' , true);
+  });
+
+  test('observe (multiple; array)', 12, function() {
+
+    model.set({'water':'fountain', 'candy':'twix'});
+    view.model = model;
+    view.templateId = 'jst5';
+    view.bindings = {
+      '#test5': {
+        observe: ['water', 'candy'],
+        onGet: function(val, modelAttr) {
+          _.each(modelAttr, _.bind(function(attr, i) {
+            equal(val[i], this.model.get(attr));
+          }, this));
+          equal(modelAttr.toString(), 'water,candy');
+          return model.get('water') + ' ' + model.get('candy');
+        }
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test5').text(), 'fountain twix');
+
+    model.set('water', 'evian');
+    equal(view.$('#test5').text(), 'evian twix');
+
+    model.set('candy', 'snickers');
+    equal(view.$('#test5').text(), 'evian snickers');
+  });
+
+  test('bindings:updateView', 6, function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst1';
+    view.bindings = {
+      '#test1': {
+        observe: 'water',
+        updateView: function(val) {
+          equal(val, model.get('water'));
+          return val == 'evian';
+        }
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test1').val(), '');
+
+    model.set({water:'evian'});
+    equal(view.$('#test1').val(), 'evian');
+
+    model.set({water:'dasina'});
+    equal(view.$('#test1').val(), 'evian');
+  });
+
+  test('bindings:updateModel', 6, function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst1';
+    view.bindings = {
+      '#test1': {
+        observe: 'water',
+        updateModel: function(val, attrName) {
+          equal(val, view.$('#test1').val());
+          equal(attrName, 'water');
+          return val == 'evian';
+        }
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    view.$('#test1').val('dasina').keyup();
+    equal(model.get('water'), 'fountain');
+
+    view.$('#test1').val('evian').keyup();
+    equal(model.get('water'), 'evian');
+  });
+
+  test('bindings:eventsOverride', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst1';
+    view.bindings = {
+      '#test1': {
+        observe: 'water',
+        eventsOverride: ['blur', 'keydown']
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test1').val(), 'fountain');
+
+    // keyup should be overriden, so no change...
+    view.$('#test1').val('dasina').keyup();
+    equal(model.get('water'), 'fountain');
+
+    view.$('#test1').blur();
+    equal(model.get('water'), 'dasina');
+
+    view.$('#test1').val('evian').keydown();
+    equal(model.get('water'), 'evian');
+  });
+
+  test('bindings:modelAttr (deprecated)', function() {
+
+    model.set({'water':'fountain'});
+    view.model = model;
+    view.templateId = 'jst1';
+    view.bindings = {
+      '#test1': {
+        modelAttr: 'water'
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test1').val(), 'fountain');
+
+    model.set('water', 'evian');
+    equal(view.$('#test1').val(), 'evian');
+
+    view.$('#test1').val('dasina').keyup();
+    equal(model.get('water'), 'dasina');
+  });
+
+  test('checkbox multiple', function() {
+
+    model.set({'water':['fountain', 'dasina']});
+    view.model = model;
+    view.templateId = 'jst18';
+    view.bindings = {
+      '.boxes': 'water'
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('.boxes[value="fountain"]').prop('checked'), true);
+    equal(view.$('.boxes[value="evian"]').prop('checked'), false);
+    equal(view.$('.boxes[value="dasina"]').prop('checked'), true);
+
+    model.set('water', ['evian']);
+    equal(view.$('.boxes[value="fountain"]').prop('checked'), false);
+    equal(view.$('.boxes[value="evian"]').prop('checked'), true);
+    equal(view.$('.boxes[value="dasina"]').prop('checked'), false);
+
+    view.$('.boxes[value="dasina"]').prop('checked', true).change();
+    equal(model.get('water').length, 2);
+    equal(_.indexOf(model.get('water'), 'evian') > -1, true);
+    equal(_.indexOf(model.get('water'), 'dasina') > -1, true);
+  });
+
+  test('checkbox (single with value defined)', function() {
+
+    model.set({'water':null});
+    view.model = model;
+    view.templateId = 'jst19';
+    view.bindings = {
+      '.box': 'water'
+    };
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('.box').prop('checked'), false);
+
+    model.set('water', 'fountain');
+    equal(view.$('.box').prop('checked'), true);
+
+    view.$('.box').prop('checked', false).change();
+    equal(model.get('water'), null);
+  });
 
 });

--- a/test/modelBinding.js
+++ b/test/modelBinding.js
@@ -1,93 +1,93 @@
 $(document).ready(function() {
 
-	module("view.unstickModel");
+  module("view.unstickModel");
 
-	test('unstickModel', function() {
-		
-		model.set({'water':'fountain', 'test':'nada', 'copy':'cat', 'fickle':'brat'});
-		view.model = model;
-		view.templateId = 'jst10';
-		view.bindings = {
-			'.test10': {
-				observe: 'water',
-				attributes: [{
-					name: 'class',
-					observe: 'copy'
-				}, {
-					name: 'data-test',
-					observe: 'fickle'
-				}]
-			}
-		};
-		$('#qunit-fixture').html(view.render().el);
+  test('unstickModel', function() {
 
-		equal(_.keys(view.model._callbacks).length, 3);
+    model.set({'water':'fountain', 'test':'nada', 'copy':'cat', 'fickle':'brat'});
+    view.model = model;
+    view.templateId = 'jst10';
+    view.bindings = {
+      '.test10': {
+        observe: 'water',
+        attributes: [{
+          name: 'class',
+          observe: 'copy'
+        }, {
+          name: 'data-test',
+          observe: 'fickle'
+        }]
+      }
+    };
+    $('#qunit-fixture').html(view.render().el);
 
-		view.unstickModel();
+    equal(_.keys(view.model._callbacks).length, 3);
 
-		equal(_.keys(view.model._callbacks).length, 0);
-	});
+    view.unstickModel();
 
-	test('unstickModel (multiple models across multiple views)', function() {
-		
-		var model1, model2, view, view2, model3;
+    equal(_.keys(view.model._callbacks).length, 0);
+  });
 
-		model1 = new (Backbone.Model)({one:'', two:''});
-		model2 = new (Backbone.Model)({three:'', four:''});
-		model3 = new (Backbone.Model)({five:'', six:''});
+  test('unstickModel (multiple models across multiple views)', function() {
 
-		view = new (Backbone.View.extend({
-			initialize: function() {
-				this.model = model1;
-			},
-			bindings: {
-				'.test12-1': 'one',
-				'.test12-2': 'two'
-			},
-			otherBindings: {
-				'.test12-3': 'three',
-				'.test12-4': 'four'
-			},
-			render: function() {
-				var html = document.getElementById('jst12').innerHTML;
-				this.$el.html(_.template(html)());
-				this.stickit();
-				this.stickit(model2, this.otherBindings);
-				return this;
-			}
-		}))().render();
+    var model1, model2, view, view2, model3;
 
-		view2 = new (Backbone.View.extend({
-			bindings: {
-				'.test13-5': 'five',
-				'.test13-6': 'six'
-			},
-			render: function() {
-				var html = document.getElementById('jst13').innerHTML;
-				this.$el.html(_.template(html)());
-				this.stickit(model3);
-				return this;
-			}
-		}))().render();
+    model1 = new (Backbone.Model)({one:'', two:''});
+    model2 = new (Backbone.Model)({three:'', four:''});
+    model3 = new (Backbone.Model)({five:'', six:''});
+
+    view = new (Backbone.View.extend({
+      initialize: function() {
+        this.model = model1;
+      },
+      bindings: {
+        '.test12-1': 'one',
+        '.test12-2': 'two'
+      },
+      otherBindings: {
+        '.test12-3': 'three',
+        '.test12-4': 'four'
+      },
+      render: function() {
+        var html = document.getElementById('jst12').innerHTML;
+        this.$el.html(_.template(html)());
+        this.stickit();
+        this.stickit(model2, this.otherBindings);
+        return this;
+      }
+    }))().render();
+
+    view2 = new (Backbone.View.extend({
+      bindings: {
+        '.test13-5': 'five',
+        '.test13-6': 'six'
+      },
+      render: function() {
+        var html = document.getElementById('jst13').innerHTML;
+        this.$el.html(_.template(html)());
+        this.stickit(model3);
+        return this;
+      }
+    }))().render();
 
 
-		equal(_.keys(model1._callbacks).length, 2);
-		equal(_.keys(model2._callbacks).length, 2);
-		equal(_.keys(model3._callbacks).length, 2);
-		equal(view._modelBindings.length, 4);
-		equal(view2._modelBindings.length, 2);
+    equal(_.keys(model1._callbacks).length, 2);
+    equal(_.keys(model2._callbacks).length, 2);
+    equal(_.keys(model3._callbacks).length, 2);
+    equal(view._modelBindings.length, 4);
+    equal(view2._modelBindings.length, 2);
 
-		view.unstickModel();
+    view.unstickModel();
 
-		equal(_.keys(model1._callbacks).length, 0);
-		equal(_.keys(model2._callbacks).length, 0);
-		equal(view._modelBindings.length, 0);
-		equal(_.keys(model3._callbacks).length, 2);
+    equal(_.keys(model1._callbacks).length, 0);
+    equal(_.keys(model2._callbacks).length, 0);
+    equal(view._modelBindings.length, 0);
+    equal(_.keys(model3._callbacks).length, 2);
 
-		view2.unstickModel();
+    view2.unstickModel();
 
-		equal(_.keys(model3._callbacks).length, 0);
-		equal(view2._modelBindings.length, 0);
-	});
+    equal(_.keys(model3._callbacks).length, 0);
+    equal(view2._modelBindings.length, 0);
+  });
 
 });

--- a/test/testScaffolding.js
+++ b/test/testScaffolding.js
@@ -1,26 +1,26 @@
 $(document).ready(function() {
 
-	QUnit.testStart =function() {
-		
-		window.view = new (Backbone.View.extend({
-			model: null,
-			templateId: '',
-			render: function() {
-				var html = document.getElementById(this.templateId).innerHTML;
-				this.$el.html(_.template(html)());
-				this.stickit();
-				return this;
-			}
-		}))();
+  QUnit.testStart =function() {
 
-		window.model = new (Backbone.Model.extend())();
-	};
+    window.view = new (Backbone.View.extend({
+      model: null,
+      templateId: '',
+      render: function() {
+        var html = document.getElementById(this.templateId).innerHTML;
+        this.$el.html(_.template(html)());
+        this.stickit();
+        return this;
+      }
+    }))();
 
-	QUnit.testDone = function() {
-		model.off();
-		delete window.model;
-		view.remove();
-		delete window.view;
-	};
+    window.model = new (Backbone.Model.extend())();
+  };
+
+  QUnit.testDone = function() {
+    model.off();
+    delete window.model;
+    view.remove();
+    delete window.view;
+  };
 
 });


### PR DESCRIPTION
Our use of stickit in titanium-backbone requires the ability to override the way elements are queried and updated. This commit moves isObservable (which replaces isFormEl($el) || isContenteditable($el)), updateEl, and getElVal to Backbone.Stickit, which can be changed by a library that uses Backbone.stickit.

For example, in titanium-backbone we can then do:

``` coffeescript
_.extend Backbone.Stickit,

  isObservable: ($el) ->
    $el[0]._viewName in ['TextField', 'TextArea']

  updateEl: ($el, val, config) ->

    updateMethod = config.updateMethod || 'text';

    switch $el[0]._viewName
      when 'TextField', 'TextArea'
        $el.val val
      else
        $el[updateMethod] val

  getElVal: ($el) ->

    switch $el[0]._viewName
      when 'TextField', 'TextArea'
        $el.val()
```

Is this idea worth pursuing further? I can certainly keep it in a separate fork but if others find value then I'd be happy to do any needed cleanup work (it passes all tests as-is but could probably be cleaned up a bit).
