### PR TITLE
option:selected fix for zepto

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -252,11 +252,11 @@
 				}
 			} else if (isSelect($el)) {
 				if ($el.prop('multiple')) {
-					val = $el.find('option:selected').map(function() {
+					val = $el.find('option').not(function(){ return !this.selected }).map(function() {
 						return $(this).data('stickit_bind_val');
 					}).get();
 				} else {
-					val = $el.find('option:selected').data('stickit_bind_val');
+					val = $el.find('option').not(function(){ return !this.selected }).data('stickit_bind_val');
 				}
 			}
 			else val = $el.val();


### PR DESCRIPTION
zepto does not support the ":selected" pseudo selector and thus breaks building a select form field using selectOptions. i've updated this option selecting function to work without the use of the pseudo selector.
