### PR TITLE
Fix for issue #86

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -373,7 +373,7 @@
             list[label] = getList($(el).find('option'));
           });
         } else {
-          list = getList($el);
+          list = getList($el.find('option'));
         }
       }
 


### PR DESCRIPTION
Added handling of options without optgroup when one or more optgroups are present for pre-rendered selects
