### PR TITLE
Return the view on remove() to allow chaining.

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -120,6 +120,7 @@
       this.remove = _.wrap(this.remove, function(oldRemove) {
         self.unstickit();
         if (oldRemove) oldRemove.call(self);
+        return self;
       });
     }
   });


### PR DESCRIPTION
Hi,

This change is in line with the changes Backbone made to their API in version 1.0. 

P.S. I came to backbone.stickit after working with Rivetjs and actually coming close to abandoning Backbone entirely for a framework with declarative data-bindings built in. Now I'm so glad I didn't. I think the imperative style embraced here makes a ton of sense, not only in terms of Backbone's conventions, but JS development in general. 

So, just wanted to say, thanks for pointing the way and for open-sourcing this solution. 

Look forward to contribute more (and more substantially) in the future. 

Best,
Sean
