### PR TITLE
Fix visible observed attribute overwriting DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Called for each binding after it is configured in the initial call to `stickit()
 ### visible and visibleFn
 
 When true, `visible` shows or hides the view element based on the model attribute's truthiness. `visible` may also be defined with a callback which should return a truthy value.
+The `updateView` option defaults to `false` when using `visible`.  You must opt-in to `updateView` in order to have both view element visibility and value changes bound to the observed attribute.
 
 If more than the standard jQuery show/hide is required, then you can manually take control by defining `visibleFn` with a callback. 
 
@@ -277,7 +278,8 @@ If more than the standard jQuery show/hide is required, then you can manually ta
   bindings: {
     '#title': {
       observe: 'title',
-      visible: function(val, options) { return val == 'Mille Plateaux'; }
+      visible: function(val, options) { return val == 'Mille Plateaux'; },
+      updateView: true
     }
   }
 ```

--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -87,7 +87,7 @@
 
         initializeAttributes(self, $el, config, model, modelAttr);
 
-        initializeVisible(self, $el, config, model, modelAttr);
+        initializeVisible(self, $el, config, model, modelAttr, binding.updateView);
 
         if (modelAttr) {
           // Setup one-way, form element to model, bindings.
@@ -243,8 +243,9 @@
   //     visible: true, // or function(val, options) {}
   //     visibleFn: function($el, isVisible, options) {} // optional handler
   //
-  var initializeVisible = function(view, $el, config, model, modelAttr) {
+  var initializeVisible = function(view, $el, config, model, modelAttr, updateView) {
     if (config.visible == null) return;
+    config.updateView = updateView || false;
     var visibleCb = function() {
       var visible = config.visible,
           visibleFn = config.visibleFn,
@@ -274,7 +275,6 @@
   //
   var updateViewBindEl = function(view, $el, config, val, model, isInitializing) {
     if (!evaluateBoolean(view, config.updateView, val, config)) return;
-    if (config.visible) return;
     config.update.call(view, $el, val, model, config);
     if (!isInitializing) applyViewFn(view, config.afterUpdate, $el, val, config);
   };

--- a/test/bindData.js
+++ b/test/bindData.js
@@ -1092,9 +1092,9 @@ $(document).ready(function() {
     equal(Number(view.$('#test11').val()), 2);
   });
 
-  test('visible', 21, function() {
+  test('visible', 25, function() {
 
-    model.set({'water':false, 'candy':'twix', 'costume':false});
+    model.set({'water':false, 'candy':'twix', 'costume':false, 'visible': 'yes'});
     view.model = model;
     view.templateId = 'jst14';
     view.bindings = {
@@ -1118,6 +1118,11 @@ $(document).ready(function() {
           ok(isVisible);
           equal(options.observe.toString(), 'candy,costume');
         }
+      },
+      '#test14-4': {
+        observe: 'visible',
+        visible: function(val) { return val == 'yes'; },
+        updateView: true
       }
     };
     $('#qunit-fixture').html(view.render().el);
@@ -1126,15 +1131,20 @@ $(document).ready(function() {
     equal(view.$('#test14-2').css('display') == 'block' , true);
     equal(view.$('#test14-2').text(), 'Test');
     equal(view.$('#test14-3').css('display') == 'block' , true);
+    equal(view.$('#test14-4').css('display') == 'block' , true);
+    equal(view.$('#test14-4').text(), 'yes');
 
     model.set('water', true);
     model.set('candy', 'snickers');
     model.set('costume', true);
+    model.set('visible', 'no')
 
     equal(view.$('#test14-1').css('display') == 'block' , true);
     equal(view.$('#test14-2').css('display') == 'block' , false);
     equal(view.$('#test14-2').text(), 'Test');
     equal(view.$('#test14-3').css('display') == 'block' , true);
+    equal(view.$('#test14-4').css('display') == 'block' , false);
+    equal(view.$('#test14-4').text(), 'no');
   });
 
   test('observe (multiple; array)', 12, function() {

--- a/test/index.html
+++ b/test/index.html
@@ -81,6 +81,7 @@
 		<div id="test14-1"></div>
 		<div id="test14-2">Test</div>
 		<div id="test14-3"></div>
+        <div id="test14-4">Test 2</div>
 	</script>
 
 	<script id="jst15" type="text/jst">


### PR DESCRIPTION
This fixes an issue where using the `visible: true` visibility option in a binding
will cause the value of the observed attribute to be set via the `$.text()`
jQuery method on the selected element.  An example of the behavior can be seen
here: http://jsbin.com/udapeb/8/edit

This patch sets `updateView` to `false` for `visible: true` bindings.
Additionally, there is an existence check in the default text binding handler.

Tests updated to verify the content of the bound element.
