### PR TITLE
Add ability to specify function as 'observe'

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -73,6 +73,7 @@
 
         // Allow shorthand setting of model attributes - `'selector':'observe'`.
         if (_.isString(binding)) binding = {observe:binding};
+        if (_.isFunction(binding.observe)) {binding.observe = binding.observe.call(self, model);}
 
         config = getConfiguration($el, binding);
 

--- a/test/bindData.js
+++ b/test/bindData.js
@@ -1163,6 +1163,42 @@ $(document).ready(function() {
     equal(view.$('#test5').text(), 'evian snickers');
   });
 
+  test('observe (function)', function() {
+    model.set({'water':'fountain'});
+
+    var testView = new (Backbone.View.extend({
+      bindings: {
+        '#test1': {
+          observe: function(m) {
+            equal(model, m);
+            equal(this, testView);
+            equal(this.options.observeValue, 'water');
+            return this.options.observeValue;
+          }
+        }
+      },
+      render: function() {
+        var html = document.getElementById('jst1').innerHTML;
+        this.$el.html(_.template(html)());
+        this.stickit();
+        return this;
+      }
+    }))({
+      model: model,
+      observeValue: 'water'
+    });
+
+    $('#qunit-fixture').html(testView.render().el);
+
+    equal(testView.$('#test1').val(), 'fountain');
+
+    model.set('water', 'evian');
+    equal(testView.$('#test1').val(), 'evian');
+    
+    testView.$('#test1').val('dasina').trigger('keyup');
+    equal(model.get('water'), 'dasina');
+  });
+
   test('bindings:updateView', 9, function() {
 
     model.set({'water':'fountain'});


### PR DESCRIPTION
I've run into situations where I would like to have reusable views with stickit bindings, but the model attributes I would like to observe differ between view instances.  Providing for a function to be used to set the `observe`d attribute allows for a more flexible and reusable view.

Tests updated with a use case.
