### PR TITLE
Expose getConfiguration as a static method on Backbone.Stickit

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -180,8 +180,8 @@
 
   // Find handlers in `Backbone.Stickit._handlers` with selectors that match
   // `$el` and generate a configuration by mixing them in the order that they
-  // were found with the with the givne `binding`.
-  var getConfiguration = function($el, binding) {
+  // were found then with the given `binding`.
+  var getConfiguration = Backbone.Stickit.getConfiguration = function($el, binding) {
     var handlers = [{
       updateModel: false,
       updateView: true,

--- a/test/addHandler.js
+++ b/test/addHandler.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
   module("Backbone.Stickit");
 
   test('addHandler', function() {
-		
+
     Backbone.Stickit.addHandler({
       selector: 'input.trim',
       update: function($el, val) { $el.val($.trim(val)); }
@@ -30,14 +30,20 @@ $(document).ready(function() {
       'input.trim': 'input',
       '#textarea': 'textarea',
       '#div': 'div'
-	};
-	$('#qunit-fixture').html(view.render().el);
+    };
+    $('#qunit-fixture').html(view.render().el);
 
-	equal(view.$('.input').val(), ' clot ');
-	equal(view.$('input.trim').val(), 'clot');
-	equal(view.$('#textarea').val(), 'blood clot');
-	equal(view.$('#div').text(), 'clot');
+    equal(view.$('.input').val(), ' clot ');
+    equal(view.$('input.trim').val(), 'clot');
+    equal(view.$('#textarea').val(), 'blood clot');
+    equal(view.$('#div').text(), 'clot');
 
-	Backbone.Stickit._handlers = _.first(Backbone.Stickit._handlers, Backbone.Stickit._handlers.length - 3);
+    Backbone.Stickit._handlers = _.first(Backbone.Stickit._handlers, Backbone.Stickit._handlers.length - 3);
+  });
+
+  test('public getConfiguration', function(){
+    $('#qunit-fixture').html($('#jst25').html());
+    var $el = $('#qunit-fixture').find('.test25');
+    equal(Backbone.Stickit.getConfiguration($el).getVal($el), 'two');
   });
 });

--- a/test/index.html
+++ b/test/index.html
@@ -3,28 +3,28 @@
 
 <head>
   <title>backbone.stickit suite</title>
-  
-	<link rel="stylesheet" href="vendor/qunit.css" type="text/css"/>  
-	
+
+	<link rel="stylesheet" href="vendor/qunit.css" type="text/css"/>
+
 	<!--script type="text/javascript" src="vendor/zepto.js"></script>
 	<script type="text/javascript" src="vendor/zepto-data.js"></script-->
 	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-	<script type="text/javascript" src="vendor/qunit.js"></script>  
-	<script type="text/javascript" src="vendor/underscore.js"></script> 
+	<script type="text/javascript" src="vendor/qunit.js"></script>
+	<script type="text/javascript" src="vendor/underscore.js"></script>
 	<script type="text/javascript" src="vendor/backbone.js"></script>
 	<script type="text/javascript" src="../backbone.stickit.js"></script>
-	
+
 	<script type="text/javascript" src="testScaffolding.js"></script>
 	<script type="text/javascript" src="bindData.js"></script>
 	<script type="text/javascript" src="modelBinding.js"></script>
 	<script type="text/javascript" src="addHandler.js"></script>
-</head>  
-	
-<body>  
+</head>
+
+<body>
 	<h1 id="qunit-header">backbone.stickit Test Suite</h1>
-	<h2 id="qunit-banner"></h2>  
+	<h2 id="qunit-banner"></h2>
 	<h2 id="qunit-userAgent"></h2>
-	<ol id="qunit-tests"></ol> 
+	<ol id="qunit-tests"></ol>
 
 	<div id="qunit-fixture"></div>
 
@@ -43,7 +43,7 @@
 
 	<script id="jst4" type="text/jst">
 		<input type="radio" name="water" value="fountain" class="test4">
-		<input type="radio" name="water" value="evian" class="test4"> 
+		<input type="radio" name="water" value="evian" class="test4">
 	</script>
 
 	<script id="jst5" type="text/jst"><div id="test5"></div></script>
@@ -88,7 +88,7 @@
 		<input id="test15-2" type="text">
 		<input id="test15-3" type="checkbox">
 		<input class="test15-4" type="radio" name="water" value="fountain">
-		<input class="test15-4" type="radio" name="water" value="evian"> 
+		<input class="test15-4" type="radio" name="water" value="evian">
 		<textarea id="test15-6"></textarea>
 		<select id="test15-7"></select>
 	</script>
@@ -159,6 +159,11 @@
       </optgroup>
     </select>
 	</script>
+
+    <script id="jst25" type="text/jst">
+        <input type="radio" name="water" value="one" class="test25">
+        <input type="radio" name="water" checked value="two" class="test25">
+    </script>
 
 </body>
 


### PR DESCRIPTION
I really like the simplicity of this, but I have an edge case where I need to use the handlers in an external script.

I want to get the same configuration that would have been returned internally and so it would be really useful to have the getConfiguration as a static method on the namespace.

``` javascript
Backbone.Stickit.getConfiguration($el).getVal($el)
//=> value depending on $el
```
