### PR TITLE
Add view reference to stickitChange events

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -85,6 +85,8 @@
         // Create the model set options with a unique `bindId` so that we
         // can avoid double-binding in the `change:attribute` event handler.
         config.bindId = bindId;
+        // Add a reference to the view for handlers of stickitChange events
+        config.view = self;
         options = _.extend({stickitChange:config}, config.setOptions || {});
 
         initializeAttributes(self, $el, config, model, modelAttr);


### PR DESCRIPTION
It can be useful when handling stickitChange events to know which view handled that change in cases where two or more views are monitoring the same model. 

In my case, I was trying to bind multiple Chosen widgets to a single model attribute and using the [example](https://github.com/NYTimes/backbone.stickit/issues/73#issuecomment-17052649) provided in issue #73 to call `liszt:updated` when a value changed. A simple check of o.stickitChange didn't work in this case. I've modified the example below to work with the new stickitChange.view reference.

``` javascript
Backbone.Stickit.addHandler({
  selector: 'select.chosen',
  initialize: function($el, model, opt) {
    var e, up, view,
      _this = this;
    e = "change:" + opt.observe;
    $el.chosen({
      disable_search_threshold: 7
    });
    view = this;
    up = function(m, v, o) {
      if (!(o.stickitChange && o.stickitChange.view === view)) {
        return $el.trigger("liszt:updated");
      }
    };
    this.listenTo(model, e, up);
    return this.listenTo(model, 'stickit:unstuck', function() {
      return _this.stopListening(model, e, up);
    });
  }
});
```
