### PR TITLE
Wrap as AMD module

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -1,4 +1,21 @@
-(function($) {
+(function (root, factory) {
+  if (typeof exports === 'object') {
+
+    var jquery = require('jquery');
+    var underscore = require('underscore');
+    var backbone = require('backbone');
+
+    module.exports = factory(jquery, underscore, backbone);
+
+  } else if (typeof define === 'function' && define.amd) {
+
+    define(['jquery', 'underscore', 'backbone'], factory);
+
+  } else {
+    // Browser globals
+    factory(root.jQuery, root._, root.Backbone);
+  }
+}(this, function ($, _, Backbone) {
 
   // Backbone.Stickit Namespace
   // --------------------------
@@ -477,5 +494,5 @@
       return val;
     }
   }]);
-
-})(window.jQuery || window.Zepto);
+  return Backbone.Stickit;
+}));


### PR DESCRIPTION
This wraps the Stickit library in an AMD/UMD (see https://github.com/umdjs/umd/blob/master/amdWebGlobal.js) compatible wrapper, while remaining backwards-compatible as a standard `<script>` include.

All tests still pass when run with the standard test runner.
