### PR TITLE
extend selectOptions to accept value:label map

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Specify a list of events which will override stickit's default events for a form
 
 With the given `collection`, creates `<option>`s for the bound `<select>`, and binds their selected values to the observed model attribute. It is recommended to use `selectOptions` instead of pre-rendering select-options since Stickit will render them and can bind Objects, Arrays, and non-String values as data to the `<option>` values. The following are configuration options for binding:
 
- - `collection`: an object path of a collection relative to `window` or `view`/`this`, or a string function reference which returns a collection of objects. A collection should be either an  array of objects or Backbone.Collection.
+ - `collection`: an object path of a collection relative to `window` or `view`/`this`, or a string function reference which returns a collection of objects. A collection should be an array of objects, a Backbone.Collection or a value/label map.
  - `labelPath`: the path to the label value for select options within the collection of objects. Default value when undefined is `label`.
  - `valuePath`: the path to the values for select options within the collection of objects. When an options is selected, the value that is defined for the given option is set in the model. Leave this undefined if the whole object is the value or to use the default `value`.
  - `defaultOption`: an object with `label` and `value` keys, used to define a default option value. A common use case would be something like the following: `{label: "Choose one...", value: null}`.
@@ -420,6 +420,23 @@ Optgroups are supported, where the collection is formatted into an object with a
         },
         labelPath: 'name',
         valuePath: 'id'
+      }
+    }
+  }
+```
+
+It is often useful to have a lookup table for converting between underlying values which are actually stored and transmitted and the human-readable labels that represent them. Such a lookup table (an object like `{ value1: label1, value2: label2 }`) can be used to populate a select directly. By default, the options will be sorted alphabetically by label; pass a `comparator`function or property name string to override this ordering (which delegates to `_.sortBy`).
+
+```javascript
+  bindings: {
+    'select#sounds': {
+      observe: 'sound',
+      selectOptions: {
+        collection: {
+          moo: 'cow',
+          baa: 'sheep',
+          oink: 'pig'
+        }
       }
     }
   }

--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -447,9 +447,9 @@
 
       if (_.isArray(optList)) {
         addSelectOptions(optList, $el, val);
-      } else {
-        // If the optList is an object, then it should be used to define an optgroup. An
-        // optgroup object configuration looks like the following:
+      } else if (optList.opt_labels) {
+        // To define a select with optgroups, format selectOptions.collection as an object
+        // with an 'opt_labels' property, as in the following:
         //
         //     {
         //       'opt_labels': ['Looney Tunes', 'Three Stooges'],
@@ -462,6 +462,17 @@
           addSelectOptions(optList[label], $group, val);
           $el.append($group);
         });
+        // With no 'opt_labels' parameter, the object is assumed to be a simple value-label map.
+        // Pass a selectOptions.comparator to override the default order of alphabetical by label.
+      } else {
+        var opts = [], opt;
+        for (var i in optList) {
+          opt = {};
+          opt[selectConfig.valuePath] = i;
+          opt[selectConfig.labelPath] = optList[i];
+          opts.push(opt);
+        }
+        addSelectOptions(_.sortBy(opts, selectConfig.comparator || selectConfig.labelPath), $el, val);
       }
     },
     getVal: function($el) {

--- a/test/bindData.js
+++ b/test/bindData.js
@@ -747,6 +747,63 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
     equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'fountain');
   });
 
+  test('bindings:selectOptions (collection defined as value/label map)', function() {
+
+    model.set({'sound':'moo'});
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'sound',
+        selectOptions: {
+          collection: {
+            moo: 'cow',
+            baa: 'sheep',
+            oink: 'pig'
+          }
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'moo');
+
+    // Options are sorted alphabetically by label
+    equal(view.$('#test8 option:eq(0)').data('stickit_bind_val'), 'moo');
+    equal(view.$('#test8 option:eq(1)').data('stickit_bind_val'), 'oink');
+    equal(view.$('#test8 option:eq(2)').data('stickit_bind_val'), 'baa');
+  });
+
+  test('bindings:selectOptions (collection defined as value/label map, sorted by value)', function() {
+
+    model.set({'sound':'moo'});
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'sound',
+        selectOptions: {
+          collection: {
+            moo: 'cow',
+            baa: 'sheep',
+            oink: 'pig'
+          },
+          comparator: function(sound) { return sound.value; }
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'moo');
+
+    // Options are sorted alphabetically by value
+    equal(view.$('#test8 option:eq(0)').data('stickit_bind_val'), 'baa');
+    equal(view.$('#test8 option:eq(1)').data('stickit_bind_val'), 'moo');
+    equal(view.$('#test8 option:eq(2)').data('stickit_bind_val'), 'oink');
+  });
+
   test('bindings:selectOptions (multi-select without valuePath)', function() {
 
     var collection = [{id:1,name:'fountain'}, {id:2,name:'evian'}, {id:3,name:'dasina'}, {id:4,name:'aquafina'}];


### PR DESCRIPTION
It is often useful to have a lookup table for converting between underlying values which are actually stored and transmitted and the human-readable labels that represent them. This extension of selectOptions allows such a lookup table to be used to populate a select directly. By default, the options will be sorted alphabetically by label, the most common use case for a select; pass a `comparator` function or property name string to override this ordering (which delegates to `_.sortBy`).

TL;DR:

Converts

``` javascript
bindings: {
  'select#sounds': {
    observe: 'sound',
    selectOptions: {
      collection: {
        moo: 'Cow',
        baa: 'Sheep',
        oink: 'Pig'
      }
    }
  }
}
```

to

``` html
<select id='sounds'>
  <option value='moo'>Cow</option>
  <option value='oink'>Pig</option>
  <option value='baa'>Sheep</option>
</select>
```

Updated tests and docs.
