### PR TITLE
jQuery without referencing window

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -1,4 +1,4 @@
-(function($) {
+(function(Backbone, $) {
 
   // Backbone.Stickit Namespace
   // --------------------------
@@ -486,4 +486,4 @@
     }
   }]);
 
-})(jQuery || Zepto);
+})(Backbone, Backbone.$);


### PR DESCRIPTION
Allows me to manually set the local value of jQuery.  My use-case being to have a build step that wraps backbone.stickit with an AMD define()

For example:

```
define(['jquery', 'backbone'], function (jQuery, Backbone) {

    // @include components/backbone.stickit/backbone.stickit.js

    return Backbone;
});
```
