### PR TITLE
Package.json should show a depend on Backbone :)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "url": "git://github.com/nytimes/backbone.stickit"
   },
   "main": "backbone.stickit.js",
+  "dependencies": {
+    "backbone": "~0.9.0"
+  },
   "devDependencies": {
     "grunt-contrib": "~0.4.0",
     "grunt-docco": "~0.1.2",


### PR DESCRIPTION
Stickit's `package.json` manifest doesn't specify Backbone as a dependency. This seems like a no-brainer, but tools like [Brunch](http://brunch.io) look to the file to determine concatenation order based on the package's deps, which makes this property important. Adding it in here.
