### PR TITLE
add missing semicolon

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -451,7 +451,7 @@
       if (optList instanceof Backbone.Collection) optList = optList.toJSON();
 
       if (selectConfig.defaultOption) {
-        addSelectOptions(["__default__"], $el)
+        addSelectOptions(["__default__"], $el);
       }
 
       if (_.isArray(optList)) {


### PR DESCRIPTION
fix.

```
$ grunt build
Loading "clean.js" tasks...ERROR
>> TypeError: Object #<Object> has no method 'registerHelper'

Running "jshint:src" (jshint) task
Linting backbone.stickit.js...ERROR
[L454:C47] Missing semicolon.
        addSelectOptions(["__default__"], $el) 

Warning: Task "jshint:src" failed. Use --force to continue.

Aborted due to warnings.
```
