### PR TITLE
Fix failing tests

### DIFF
--- a/test/modelBinding.js
+++ b/test/modelBinding.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
 
     view.unstickit();
 
-    equal(_.keys(view.model._events).length, 1);
+    equal(_.keys(view.model._events).length, 0);
   });
 
   test('unstickit (multiple models)', function() {
@@ -71,13 +71,13 @@ $(document).ready(function() {
 
     equal(_.keys(model1._events).length, 3);
     equal(_.keys(model2._events).length, 3);
-    equal(_.keys(model3._events).length, 1);
+    equal(_.keys(model3._events).length, 0);
     equal(view._modelBindings.length, 4);
 
     view.unstickit();
 
-    equal(_.keys(model1._events).length, 1);
-    equal(_.keys(model2._events).length, 1);
+    equal(_.keys(model1._events).length, 0);
+    equal(_.keys(model2._events).length, 0);
     equal(view._modelBindings.length, 0);
   });
 


### PR DESCRIPTION
Using `.once` means no events left over after `stickit:unstuck` is called. The behavior is correct, but the test is wrong.
