### PR TITLE
Allow for nested view functions using dot notation with evaluatePath

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -154,7 +154,7 @@
   // If the given `fn` is a string, then view[fn] is called, otherwise it is
   // a function that should be executed.
   var applyViewFn = function(view, fn) {
-    if (fn) return (_.isString(fn) ? view[fn] : fn).apply(view, _.rest(arguments, 2));
+    if (fn) return (_.isString(fn) ? evaluatePath(view,fn) : fn).apply(view, _.rest(arguments, 2));
   };
 
   var getSelectedOption = function($select) { return $select.find('option').not(function(){ return !this.selected; }); };


### PR DESCRIPTION
We have some views that share methods with a helper object - eg. this.context.helperMethod.  This simple change allows for stickit bindings to reference view functions with dot notation: 

``` javascript
bindings: {
  '.price': {
    observe: 'Variants',
    onGet: 'context.getActivePrice'
  }
}
```
