### PR TITLE
Allow multiple bindings to be added without unbinding

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -66,8 +66,9 @@
     // Using `this.bindings` configuration or the `optionalBindingsConfig`, binds `this.model`
     // or the `optionalModel` to elements in the view. Pass `keepOld` as true
     // to preserve old bindings
-    stickit: function(optionalModel, optionalBindingsConfig, keepOld) {
+    stickit: function(optionalModel, optionalBindingsConfig, options) {
       var model = optionalModel || this.model,
+        keepOld = options && options.keepOld,
         namespace = '.stickit.' + model.cid,
         bindings = optionalBindingsConfig || _.result(this, "bindings") || {};
 

--- a/test/modelBinding.js
+++ b/test/modelBinding.js
@@ -120,7 +120,7 @@ $(document).ready(function() {
           this.stickit(null, null, true);
           equal(this._modelBindings.length, 2);
 
-          this.stickit(null, this.otherBindings, true);
+          this.stickit(null, this.otherBindings, {keepOld: true});
           equal(this._modelBindings.length, 4);
 
           this.stickit(null, this.moreBindings);


### PR DESCRIPTION
Addresses #159 to allow `view.stickit()` to take an optional third `keepOld` parameter and preserve old bindings.

The logic for determining if a binding exists already is if the two bindings reference the same view instance and have the same selector.

I welcome any feedback on the API or the implementation.
