### PR TITLE
Dont rebind this.remove if already bound

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -145,12 +145,14 @@
 
       // Wrap `view.remove` to unbind stickit model and dom events.
       var remove = this.remove;
+      if (remove.wrapped) return;
       this.remove = function() {
         var ret = this;
         this.unstickit();
         if (remove) ret = remove.apply(this, _.rest(arguments));
         return ret;
       };
+      this.remove.wrapped = true;
     }
   });
 

--- a/test/modelBinding.js
+++ b/test/modelBinding.js
@@ -28,6 +28,27 @@ $(document).ready(function() {
     equal(_.keys(view.model._events).length, 0);
   });
 
+  test('unstickit is only called once on remove with multiple stickits', function() {
+    view.model = model;
+    view.render = function() {
+      this.stickit();
+      this.stickit();
+      return this;
+    }
+    view.render();
+
+    var unstickit = view.unstickit, counter = 0;
+    view.unstickit = function() {
+      counter++;
+      unstickit.apply(this, arguments);
+    }
+
+    view.remove();
+
+    equal(counter, 1);
+    view.unstickit = unstickit;
+  });
+
   test('unstickit (multiple models)', function() {
 
     var model1, model2, view, model3;


### PR DESCRIPTION
When `this.stickit` is called multiple times, the remove() function is wrapped every time unnecessarily (i.e. calling stickit three times will result in unstickit being called three times on removal). 

Not sure about this implementation (the alternative is a flag on the view I guess), I'd welcome feedback.
