### PR TITLE
Wrap view.remove, without stripping arguments.

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -149,7 +149,7 @@
         this.remove = function() {
           var ret = this;
           this.unstickit();
-          if (remove) ret = remove.apply(this, _.rest(arguments));
+          if (remove) ret = remove.apply(this, arguments);
           return ret;
         };
       this.remove.stickitWrapped = true;


### PR DESCRIPTION
Currently Stickit strips the first argument of the remove function before calling the original remove function. This prevents other remove overrides from working correctly.
