### PR TITLE
Unstickit with selector should use the selector when removing the event

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -71,7 +71,7 @@
       // Cleanup the null values.
       this._modelBindings = _.compact(this._modelBindings);
 
-      this.$el.off('.stickit' + (model ? '.' + model.cid : ''));
+      this.$el.off('.stickit' + (model ? '.' + model.cid : ''), bindingSelector);
     },
 
     // Using `this.bindings` configuration or the `optionalBindingsConfig`, binds `this.model`

--- a/test/index.html
+++ b/test/index.html
@@ -83,6 +83,7 @@
 		<div id="test14-3"></div>
         <div id="test14-4">Test 2</div>
 		<div id="test14-5"></div>
+		<input type="text" id="test14-6">
 	</script>
 
 	<script id="jst15" type="text/jst">

--- a/test/modelBinding.js
+++ b/test/modelBinding.js
@@ -28,21 +28,25 @@ $(document).ready(function() {
     equal(_.keys(view.model._events).length, 0);
   });
 
-  test('unstickit with selector parameter', 3, function() {
+  test('unstickit with selector parameter', 4, function() {
 
-    model.set({'water':'fountain', 'candy':'skittles', 'album':'rival-dealer'});
+    model.set({'water':'fountain', 'candy':'skittles', 'album':'rival-dealer', 'state': 'liquid'});
     view.model = model;
     view.templateId = 'jst14';
     view.bindings = {
       '#test14-1': 'water',
       '#test14-2': 'candy',
-      '#test14-3': 'album'
+      '#test14-3': 'album',
+      '#test14-6': 'state'
     };
     $('#qunit-fixture').html(view.render().el);
-    equal(_.keys(view.model._events).length, 3);
+    equal(_.keys(view.model._events).length, 4);
     
     view.unstickit(null, '#test14-1');
-    equal(_.keys(view.model._events).length, 2);
+    equal(_.keys(view.model._events).length, 3);
+
+    view.$('#test14-6').val('solid').change();
+    equal(model.get('state'), 'solid');
 
     view.unstickit(null, view.bindings);
     equal(_.keys(view.model._events).length, 0);  


### PR DESCRIPTION
The call to unstickit() in addBinding() currently removes all stickit events for the model bound to the view's element. It should just remove the events for the current selector.
