### PR TITLE
Allow `defaultOption` to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ With the given `collection`, creates `<option>`s for the bound `<select>`, and b
  - `collection`: an object path of a collection relative to `window` or `view`/`this`, or a string function reference which returns a collection of objects. A collection should be an array of objects, a Backbone.Collection or a value/label map.
  - `labelPath`: the path to the label value for select options within the collection of objects. Default value when undefined is `label`.
  - `valuePath`: the path to the values for select options within the collection of objects. When an options is selected, the value that is defined for the given option is set in the model. Leave this undefined if the whole object is the value or to use the default `value`.
- - `defaultOption`: an object with `label` and `value` keys, used to define a default option value. A common use case would be something like the following: `{label: "Choose one...", value: null}`.
+ - `defaultOption`: an object or method that returns an object with `label` and `value` keys, used to define a default option value. A common use case would be something like the following: `{label: "Choose one...", value: null}`.
 
 When bindings are initialized, Stickit will build the `<select>` element with the `<option>`s and bindings configured. `selectOptions` are not required - if left undefined, then Stickit will expect that the `<option>`s are pre-rendered and build the collection from the DOM.
 
@@ -672,7 +672,7 @@ MIT
 
 #### Master
 - **Breaking Change**: Classes are now treated separately from other attribute bindings. Use the new `classes` hash to bind element classes to your attributes.
-
+- `defaultOption` can be defined as a function.
 #### 0.8.0
 
 - **Breaking Change**: Calling `view#stickit` a second time with the same model, will no longer unbind all previously bound bindings associated with that model; instead, it will unbind any duplicate bindings (selectors) found in the given bindings hash (or whatever's in `view.bindings`) before initializing.

--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -545,8 +545,8 @@
 
           var text, val;
           if (obj === '__default__') {
-            text = selectConfig.defaultOption.label,
-            val = selectConfig.defaultOption.value;
+            text = fieldVal.label,
+            val = fieldVal.value;
           } else {
             text = evaluatePath(obj, selectConfig.labelPath),
             val = evaluatePath(obj, selectConfig.valuePath);
@@ -596,7 +596,10 @@
       if (optList instanceof Backbone.Collection) optList = optList.toJSON();
 
       if (selectConfig.defaultOption) {
-        addSelectOptions(["__default__"], $el);
+        var option = _.isFunction(selectConfig.defaultOption) ?
+          selectConfig.defaultOption.call(this, $el, options) :
+          selectConfig.defaultOption;
+        addSelectOptions(["__default__"], $el, option);
       }
 
       if (_.isArray(optList)) {

--- a/test/bindData.js
+++ b/test/bindData.js
@@ -644,6 +644,42 @@ $(document).ready(function() {
     equal(model.get('water'), 'dasina');
   });
 
+  test('bindings:selectOptions:defaultOption (options is a method)', 8, function() {
+
+    model.set({'water':null});
+    view.model = model;
+    view.templateId = 'jst8';
+    view.bindings = {
+      '#test8': {
+        observe: 'water',
+        selectOptions: {
+          collection: function($el, options) {
+            ok($el.is('select'));
+            equal(options.observe, 'water');
+            return [{id:1,type:{name:'fountain'}}, {id:2,type:{name:'evian'}}, {id:3,type:{name:'dasina'}}];
+          },
+          defaultOption: function(){
+            return {label: 'Choose dynamic...',
+            value: null};
+          },
+          labelPath: 'type.name',
+          valuePath: 'type.name'
+        }
+      }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    equal(view.$('#test8 option').eq(0).text(), 'Choose dynamic...');
+    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), null);
+
+    model.set('water', 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+
+    view.$('#test8 option').eq(3).prop('selected', true).trigger('change');
+    equal(model.get('water'), 'dasina');
+  });
+
 test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     model.set({'water':null});


### PR DESCRIPTION
Allowing `defaultOption` to be a function in order to build options dynamically.
