### PR TITLE
Allow binding <select>s via data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,10 @@ The following is a list of the supported form elements, their binding details, a
    - model attribute value matched to a radio group `value` attribute
    - `change` event is used for handling
  - select
-   - if you choose to pre-render your select-options (unrecommended) then the binding will be configured with the "option[value]" attributes in the DOM; otherwise, see the `selectOptions` configuration.
+   - (recommended) specify `selectOptions` to have Stickit handle the rendering and option bindings of your select (see `selectOptions`)
+   - if you choose to pre-render your select-options (not recommended) then there are two ways of configuring the bindings:
+     - "data-stickit-bind-val" attributes in the DOM. This allows for binding non-string values from a prerendered <select>, assuming that you are using jQuery or a build of Zepto that includes the "data" module.
+     - "option[value]" attributes in the DOM (used if no data-stickit-bind-val is present)
    - `change` event is used for handling
 
 ### events

--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -112,8 +112,9 @@
     // `optionalModel` is ommitted, will default to the view's `model` property.
     addBinding: function(optionalModel, selector, binding) {
       var model = optionalModel || this.model,
-          namespace = '.stickit.' + model.cid,
-          binding = binding || {};
+          namespace = '.stickit.' + model.cid;
+
+      binding = binding || {};
 
       // Support jQuery-style {key: val} event maps.
       if (_.isObject(selector)) {
@@ -505,8 +506,14 @@
       if (!selectConfig) {
         selectConfig = {};
         var getList = function($el) {
-          return $el.map(function() {
-            return {value:this.value, label:this.text};
+          return $el.map(function(index, option) {
+            // Retrieve the text and value of the option, preferring "stickit-bind-val"
+            // data attribute over value property.
+            var dataVal = Backbone.$(option).data('stickit-bind-val');
+            return {
+              value: dataVal !== undefined ? dataVal : option.value,
+              label: option.text
+            };
           }).get();
         };
         if ($el.find('optgroup').length) {
@@ -540,7 +547,7 @@
             option.text(text);
             optionVal = val;
             // Save the option value as data so that we can reference it later.
-            option.data('stickit_bind_val', optionVal);
+            option.data('stickit-bind-val', optionVal);
             if (!_.isArray(optionVal) && !_.isObject(optionVal)) option.val(optionVal);
           };
 
@@ -670,10 +677,10 @@
 
       if ($el.prop('multiple')) {
         return _.map(selected, function(el) {
-          return Backbone.$(el).data('stickit_bind_val');
+          return Backbone.$(el).data('stickit-bind-val');
         });
       } else {
-        return selected.data('stickit_bind_val');
+        return selected.data('stickit-bind-val');
       }
     }
   }]);

--- a/test/bindData.js
+++ b/test/bindData.js
@@ -599,10 +599,10 @@ $(document).ready(function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'fountain');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'fountain');
 
     model.set('water', 'evian');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'evian');
 
     view.$('#test8 option').eq(2).prop('selected', true).trigger('change');
     equal(model.get('water'), 'dasina');
@@ -635,10 +635,10 @@ $(document).ready(function() {
     $('#qunit-fixture').html(view.render().el);
 
     equal(view.$('#test8 option').eq(0).text(), 'Choose one...');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), null);
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), null);
 
     model.set('water', 'evian');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'evian');
 
     view.$('#test8 option').eq(3).prop('selected', true).trigger('change');
     equal(model.get('water'), 'dasina');
@@ -671,10 +671,10 @@ $(document).ready(function() {
     $('#qunit-fixture').html(view.render().el);
 
     equal(view.$('#test8 option').eq(0).text(), 'Choose dynamic...');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), null);
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), null);
 
     model.set('water', 'evian');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'evian');
 
     view.$('#test8 option').eq(3).prop('selected', true).trigger('change');
     equal(model.get('water'), 'dasina');
@@ -710,16 +710,19 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
     $('#qunit-fixture').html(view.render().el);
 
     equal(view.$('#test8 > option').eq(0).text(), 'Choose one...');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), null);
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), null);
 
     model.set('water', 'evian');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'evian');
 
     view.$('#test8 option').eq(3).prop('selected', true).trigger('change');
     equal(model.get('water'), 'dasina');
   });
 
   test('bindings:selectOptions (pre-rendered)', 3, function() {
+
+    // Note that we're working with strings and not numeric values here - the pre-rendered <select>
+    // handling is limited to strings unless data-stickit-bind-val is specified for each <option>
 
     model.set({'water':'1'});
     view.model = model;
@@ -732,13 +735,40 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test21')).data('stickit_bind_val'), '1');
+    strictEqual(getSelectedOption(view.$('#test21')).data('stickit-bind-val'), '1');
 
     model.set('water', '2');
-    equal(getSelectedOption(view.$('#test21')).data('stickit_bind_val'), '2');
+    strictEqual(getSelectedOption(view.$('#test21')).data('stickit-bind-val'), '2');
 
     view.$('#test21 option').eq(2).prop('selected', true).trigger('change');
-    equal(model.get('water'), '3');
+    strictEqual(model.get('water'), '3');
+  });
+
+  test('bindings:selectOptions (pre-rendered, with data-stickit-bind-val)', function() {
+
+    // Here we're testing that numeric values can be bound via data-stickit-bind-val
+
+    model.set({'water': 1});
+    view.model = model;
+    view.templateId = 'jst26';
+    view.bindings = {
+        '#test26': {
+            observe: 'water'
+        }
+    };
+
+    $('#qunit-fixture').html(view.render().el);
+
+    strictEqual(getSelectedOption(view.$('#test26')).data('stickit-bind-val'), 1);
+
+    model.set('water', 2);
+    strictEqual(getSelectedOption(view.$('#test26')).data('stickit-bind-val'), 2);
+
+    view.$('#test26 option:contains("dasina")').prop('selected', true).trigger('change');
+    strictEqual(model.get('water'), 3);
+
+    view.$('#test26 option:contains("foutain")').prop('selected', true).trigger('change');
+    strictEqual(model.get('water'), 0);
   });
 
   test('bindings:selectOptions (Backbone.Collection)', function() {
@@ -760,10 +790,10 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'fountain');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'fountain');
 
     model.set('water', 'evian');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'evian');
 
     view.$('#test8 option').eq(2).prop('selected', true).trigger('change');
     equal(model.get('water'), 'dasina');
@@ -788,17 +818,17 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'fountain');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'fountain');
 
     model.set('water', 'evian');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'evian');
 
     view.$('#test8 option').eq(2).prop('selected', true).trigger('change');
     equal(model.get('water'), 'dasina');
 
     // Test that the select options are auto-updated
     collection.add({id:4,name:'buxton'});
-    equal(view.$('#test8 option').eq(3).data('stickit_bind_val'), 'buxton');
+    equal(view.$('#test8 option').eq(3).data('stickit-bind-val'), 'buxton');
 
     var modelEvents = ['stickit:unstuck', 'stickit:selectRefresh'];
     var collectionEvents = ['stickit:selectRefresh', 'add', 'remove', 'reset', 'sort'];
@@ -857,10 +887,10 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'fountain');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'fountain');
 
     model.set('water', 'evian');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'evian');
 
     view.$('#test8 option').eq(2).prop('selected', true).trigger('change');
     equal(model.get('water'), 'dasina');
@@ -885,10 +915,10 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
     };
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val').id, 1);
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val').id, 1);
 
     model.set('water', {id:2, name:'evian'});
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val').id, 2);
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val').id, 2);
 
     view.$('#test8 option').eq(2).prop('selected', true).trigger('change');
     equal(model.get('water').id, 3);
@@ -914,11 +944,11 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'session');
-    equal(view.$('#test8 option').eq(0).data('stickit_bind_val'), '');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'session');
+    equal(view.$('#test8 option').eq(0).data('stickit-bind-val'), '');
 
     model.set('water', '');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), '');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), '');
   });
 
   test('bindings:selectOptions (default labelPath/valuePath)', function() {
@@ -939,10 +969,10 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'evian');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'evian');
 
     model.set('water', 'fountain');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'fountain');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'fountain');
   });
 
   test('bindings:selectOptions (collection defined as value/label map)', function() {
@@ -965,12 +995,12 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'moo');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'moo');
 
     // Options are sorted alphabetically by label
-    equal(view.$('#test8 option:eq(0)').data('stickit_bind_val'), 'moo');
-    equal(view.$('#test8 option:eq(1)').data('stickit_bind_val'), 'oink');
-    equal(view.$('#test8 option:eq(2)').data('stickit_bind_val'), 'baa');
+    equal(view.$('#test8 option:eq(0)').data('stickit-bind-val'), 'moo');
+    equal(view.$('#test8 option:eq(1)').data('stickit-bind-val'), 'oink');
+    equal(view.$('#test8 option:eq(2)').data('stickit-bind-val'), 'baa');
   });
 
   test('bindings:selectOptions (collection defined as value/label map, sorted by value)', function() {
@@ -994,12 +1024,12 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 'moo');
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 'moo');
 
     // Options are sorted alphabetically by value
-    equal(view.$('#test8 option:eq(0)').data('stickit_bind_val'), 'baa');
-    equal(view.$('#test8 option:eq(1)').data('stickit_bind_val'), 'moo');
-    equal(view.$('#test8 option:eq(2)').data('stickit_bind_val'), 'oink');
+    equal(view.$('#test8 option:eq(0)').data('stickit-bind-val'), 'baa');
+    equal(view.$('#test8 option:eq(1)').data('stickit-bind-val'), 'moo');
+    equal(view.$('#test8 option:eq(2)').data('stickit-bind-val'), 'oink');
   });
 
   test('bindings:selectOptions (multi-select without valuePath)', function() {
@@ -1021,14 +1051,14 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test16')).eq(0).data('stickit_bind_val').name, 'fountain');
-    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit_bind_val').name, 'dasina');
+    equal(getSelectedOption(view.$('#test16')).eq(0).data('stickit-bind-val').name, 'fountain');
+    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit-bind-val').name, 'dasina');
 
     var field = _.clone(model.get('water'));
     field.push({id:2,name:'evian'});
 
     model.set({'water':field});
-    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit_bind_val').name, 'evian');
+    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit-bind-val').name, 'evian');
 
     view.$('#test16 option').eq(3).prop('selected', true).trigger('change');
 
@@ -1056,14 +1086,14 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test16')).eq(0).data('stickit_bind_val'), 1);
-    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit_bind_val'), 3);
+    equal(getSelectedOption(view.$('#test16')).eq(0).data('stickit-bind-val'), 1);
+    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit-bind-val'), 3);
 
     var field = _.clone(model.get('water'));
     field.push(2);
 
     model.set({'water':field});
-    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit_bind_val'), 2);
+    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit-bind-val'), 2);
 
     view.$('#test16 option').eq(3).prop('selected', true).trigger('change');
 
@@ -1084,14 +1114,14 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test23')).eq(0).data('stickit_bind_val'), '1');
-    equal(getSelectedOption(view.$('#test23')).eq(1).data('stickit_bind_val'), '3');
+    equal(getSelectedOption(view.$('#test23')).eq(0).data('stickit-bind-val'), '1');
+    equal(getSelectedOption(view.$('#test23')).eq(1).data('stickit-bind-val'), '3');
 
     var field = _.clone(model.get('water'));
     field.push('2');
 
     model.set({'water':field});
-    equal(getSelectedOption(view.$('#test23')).eq(1).data('stickit_bind_val'), '2');
+    equal(getSelectedOption(view.$('#test23')).eq(1).data('stickit-bind-val'), '2');
 
     view.$('#test23 option').eq(3).prop('selected', true).trigger('change');
 
@@ -1125,14 +1155,14 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     $('#qunit-fixture').html(view.render().el);
 
-    equal(getSelectedOption(view.$('#test16')).eq(0).data('stickit_bind_val'), 1);
-    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit_bind_val'), 3);
+    equal(getSelectedOption(view.$('#test16')).eq(0).data('stickit-bind-val'), 1);
+    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit-bind-val'), 3);
 
     var field = _.clone(model.get('water'));
     field += '-2';
 
     model.set({'water':field});
-    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit_bind_val'), 2);
+    equal(getSelectedOption(view.$('#test16')).eq(1).data('stickit-bind-val'), 2);
 
     view.$('#test16 option').eq(3).prop('selected', true).trigger('change');
 
@@ -1166,10 +1196,10 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     equal(getSelectedOption(view.$('#test8')).parent().is('optgroup'), true);
     equal(getSelectedOption(view.$('#test8')).parent().attr('label'), 'Three Stooges');
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 3);
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 3);
 
     model.set({'character':2});
-    equal(getSelectedOption(view.$('#test8')).data('stickit_bind_val'), 2);
+    equal(getSelectedOption(view.$('#test8')).data('stickit-bind-val'), 2);
 
     view.$('#test8 option').eq(3).prop('selected', true).trigger('change');
     equal(model.get('character'), 4);
@@ -1190,10 +1220,10 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     equal(getSelectedOption(view.$('#test22')).parent().is('optgroup'), true);
     equal(getSelectedOption(view.$('#test22')).parent().attr('label'), 'Three Stooges');
-    equal(getSelectedOption(view.$('#test22')).data('stickit_bind_val'), '3');
+    equal(getSelectedOption(view.$('#test22')).data('stickit-bind-val'), '3');
 
     model.set({'character':'2'});
-    equal(getSelectedOption(view.$('#test22')).data('stickit_bind_val'), '2');
+    equal(getSelectedOption(view.$('#test22')).data('stickit-bind-val'), '2');
 
     view.$('#test22 option').eq(3).prop('selected', true).trigger('change');
     equal(model.get('character'), '4');
@@ -1214,10 +1244,10 @@ test('bindings:selectOptions:defaultOption:OptGroups', 8, function() {
 
     equal(getSelectedOption(view.$('#test24')).parent().is('optgroup'), true);
     equal(getSelectedOption(view.$('#test24')).parent().attr('label'), 'Three Stooges');
-    equal(getSelectedOption(view.$('#test24')).data('stickit_bind_val'), '3');
+    equal(getSelectedOption(view.$('#test24')).data('stickit-bind-val'), '3');
 
     model.set({'character':'0'});
-    equal(getSelectedOption(view.$('#test24')).data('stickit_bind_val'), '0');
+    equal(getSelectedOption(view.$('#test24')).data('stickit-bind-val'), '0');
 
     view.$('#test24 option').eq(4).prop('selected', true).trigger('change');
     equal(model.get('character'), '4');

--- a/test/index.html
+++ b/test/index.html
@@ -168,6 +168,16 @@
     <input type="radio" name="water" checked value="two" class="test25">
   </script>
 
+  <script id="jst26" type="text/jst">
+    <select id="test26">
+      <option value="0" data-stickit-bind-val="0">foutain</option>
+      <option value="1" data-stickit-bind-val="1">structured</option>
+      <option value="2" data-stickit-bind-val="2">evian</option>
+      <option value="3" data-stickit-bind-val="3">dasina</option>
+      <option value="4" data-stickit-bind-val="4">aquafina</option>
+    </select>
+  </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
This attempts to resolve #249 by allowing pre-rendered `<select>` `<option>`s to have values bound from a data attribute (`data-stickit-bind-val`, which was previously used only internally and named `data-stickit_bind_val`), rather than from the `<option value>`.

The tests now verify that pre-rendered `<select>`s without `data-stickit-bind-val` continue to have their options processed to a collection containing string values, and that ones with `data-stickit-bind-val` now support numeric values.

This fixes a longstanding issue with binding pre-rendered selects at the cost of some extra complexity and a bit of duplicative markup.
