### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "description": "Backbone data binding, model binding plugin. The real logic-less templates.",
   "homepage": "http://nytimes.github.io/backbone.stickit/",
   "main": ["./backbone.stickit.js"],
-  "version": "0.9.2",
   "license": "https://github.com/NYTimes/backbone.stickit/blob/master/LICENSE",
   "keywords": ["backbone", "data-binding", "client", "browser"],
   "author": {


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property