### PR TITLE
Added support to UI property from marionette framework

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -83,8 +83,11 @@
     // can either call `stickit` with the new bindings, or add them directly
     // with `addBinding`. Both arguments to `stickit` are optional.
     stickit: function(optionalModel, optionalBindingsConfig) {
+      // Applies uibondings acordly to marionette.ui property when available
+      var uiBindings = (typeof Marionette !== undefined) ? Marionette.normalizeUIKeys(_.result(this, 'bindings'), _.result(this, '_uiBindings')) : undefined;
+
       var model = optionalModel || this.model,
-          bindings = optionalBindingsConfig || _.result(this, "bindings") || {};
+          bindings = optionalBindingsConfig || uiBindings || _.result(this, 'bindings') || {};
 
       this._modelBindings || (this._modelBindings = []);
 


### PR DESCRIPTION
At my project i use marionette framework and when you use marionette Views you can set a new property called UI which points to the HTML elements into the view, it's good for maintenance and other things like memory management... I don't actually know if would be interest of you guys to accept this PR as it's focused into a specific framework, but i would like to let this code here so if another one which uses marionette tries to implement this i've already did it...

```
var MyView = Marionette.ItemView.extend({
  ui: {
    email: "input[name=email]"
  },

  bindings: {
    "@ui.email": "email" // Same as fill with input[name=email]
  }
});
```