### PR TITLE
added binding syntax for marionette.js

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -86,6 +86,15 @@
       var model = optionalModel || this.model,
           bindings = optionalBindingsConfig || _.result(this, "bindings") || {};
 
+      // Support of Marionette.js syntax same as for events and triggers
+      // does not brake Backbone only usage
+      // now bindings can have selector like '@ui.someSelectorName'
+      // and value for this selector gets from view.ui object
+      // see http://marionettejs.com/docs/v2.4.3/marionette.view.html#viewevents
+      if (this.normalizeUIKeys) {
+        bindings = this.normalizeUIKeys(bindings);
+      }
+
       this._modelBindings || (this._modelBindings = []);
 
       // Add bindings in bulk using `addBinding`.


### PR DESCRIPTION
Support of Marionette.js syntax same as for events and triggers
does not brake Backbone only usage
now bindings can have selector like '@ui.someSelectorName'
and value for this selector gets from view.ui object
see on http://marionettejs.com/docs/v2.4.3/marionette.view.html#viewevents

<img width="302" alt="screenshot 2015-10-05 14 54 59" src="https://cloud.githubusercontent.com/assets/7359415/10279777/17f7e0ec-6b71-11e5-96fe-1832b655489b.png">
