### PR TITLE
function call for path

### DIFF
--- a/backbone.stickit.js
+++ b/backbone.stickit.js
@@ -211,8 +211,17 @@
   // Evaluates the given `path` (in object/dot-notation) relative to the given
   // `obj`. If the path is null/undefined, then the given `obj` is returned.
   var evaluatePath = function(obj, path) {
-    var parts = (path || '').split('.');
-    var result = _.reduce(parts, function(memo, i) { return memo[i]; }, obj);
+      var result = null;
+      if ( typeof path=='function')
+      {
+          result = path.call(null,obj);
+      }
+      else
+      {
+          // previous
+          var parts = (path || '').split('.');
+          result    = _.reduce(parts, function (memo, i) { return memo[ i ]; }, obj);
+      }
     return result == null ? obj : result;
   };
 


### PR DESCRIPTION
In evaluatePath, if the path is a function, then call it go get the resulting value.
This is very usefull for select boxes, where the label can be a function returning a composition of the different attributes of the model :
                    labelPath: function (v) { return v.structure_name + ', ' + v.department_name; },
